### PR TITLE
Local `tee`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ one to compare implementations.
     - [Combinatorial Benchmarks](#combinatorial-benchmarks)
         - [Queens](#queens)
         - [Tic-Tac-Toe](#tic-tac-toe)
-        - [Picotrav](#picotrav)
     - [SAT Solver Benchmarks](#sat-solver-benchmarks)
         - [Queens](#queens-1)
         - [Pigeonhole Principle](#pigeonhole-principle)
+    - [Verification](#verification)
+        - [Picotrav](#picotrav)
     - [License](#license)
     - [References](#references)
 
@@ -191,40 +192,6 @@ intermediate result.
 | Apply operations  |              76 |
 | Initial BDD size  | (64-N+1)(N+1)-1 |
 
-### Picotrav
-This benchmark is a small recreation of the _Nanotrav_ example provided with the
-CUDD library. Given a hierarchical circuit in (a subset of the) [Berkeley Logic
-Interchange Format (BLIF)](https://course.ece.cmu.edu/~ee760/760docs/blif.pdf) a
-BDD is created for every net; dereferencing BDDs for intermediate nets after
-they have been used for the last time. If two _.blif_ files are given, then BDDs
-for both are constructed and every output net is compared for equality.
-
-BDD variables represent the value of inputs. Hence, a good variable ordering is
-important for a high performance. To this end, one can use various variable
-orderings derived from the given net.
-
-- `INPUT`: Use the order in which they are declared in the input _.blif_ file.
-
-- `DFS`: Variables are ordered based on a DFS traversal where non-input gates
-  are recursed to first; thereby favouring deeper nodes.
-
-- `LEVEL`: Variables are ordered based on the deepest reference by another net.
-  Ties are broken based on the declaration order in the input (`INPUT`).
-
-- `LEVEL_DFS`: Similar to `LEVEL` but ties are broken based on the ordering in
-  `DFS` rather than `INPUT`.
-
-- `RANDOM`: A randomized ordering of variables.
-
-The _.blif_ file(s) is given with the `-f` parameter (_F1_ and _F2_ Make
-variables) and the variable order with `-o` (_O_ for Make). You can find
-multiple inputs in the _benchmarks/_ folder.
-
-Note, that the memory you set is only for the BDD package. So, the program will
-either use swap or be killed if the BDD package takes up more memory in
-conjunction with auxiliary data structures.
-
-
 ## SAT Solver Benchmarks
 We have a few benchmarks using a simple SAT Solver based on the description in
 [[Pan04; Section 2](#references)]. 
@@ -258,6 +225,40 @@ Based on [[Tveretina10](#references)], this is disproven by use of variables
 _P<sub>i,j</sub>_ saying that the _i_'th pigeon is mapped to the _j_'th hole.
 This makes for N(N+1) labels and N³ + N(N+1) clauses.
 
+## Verification
+
+### Picotrav
+This benchmark is a small recreation of the _Nanotrav_ example provided with the
+CUDD library. Given a hierarchical circuit in (a subset of the) [Berkeley Logic
+Interchange Format (BLIF)](https://course.ece.cmu.edu/~ee760/760docs/blif.pdf) a
+BDD is created for every net; dereferencing BDDs for intermediate nets after
+they have been used for the last time. If two _.blif_ files are given, then BDDs
+for both are constructed and every output net is compared for equality.
+
+BDD variables represent the value of inputs. Hence, a good variable ordering is
+important for a high performance. To this end, one can use various variable
+orderings derived from the given net.
+
+- `INPUT`: Use the order in which they are declared in the input _.blif_ file.
+
+- `DFS`: Variables are ordered based on a DFS traversal where non-input gates
+  are recursed to first; thereby favouring deeper nodes.
+
+- `LEVEL`: Variables are ordered based on the deepest reference by another net.
+  Ties are broken based on the declaration order in the input (`INPUT`).
+
+- `LEVEL_DFS`: Similar to `LEVEL` but ties are broken based on the ordering in
+  `DFS` rather than `INPUT`.
+
+- `RANDOM`: A randomized ordering of variables.
+
+The _.blif_ file(s) is given with the `-f` parameter (_F1_ and _F2_ Make
+variables) and the variable order with `-o` (_O_ for Make). You can find
+multiple inputs in the _benchmarks/_ folder.
+
+Note, that the memory you set is only for the BDD package. So, the program will
+either use swap or be killed if the BDD package takes up more memory in
+conjunction with auxiliary data structures.
 
 ## License
 The software files in this repository are provided under the

--- a/makefile
+++ b/makefile
@@ -63,27 +63,27 @@ O := "INPUT"
 
 combinatorial/picotrav:
 combinatorial/picotrav:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_picotrav) -f $(F1) -f $(F2) -M $(M) -o $(O)
+	@$(subst VARIANT,$(V),./build/src/VARIANT_picotrav) -f $(F1) -f $(F2) -M $(M) -o $(O) | tee -a picotrav.out
 
 combinatorial/queens:
 	$(MAKE) combinatorial/queens/bdd
 
 combinatorial/queens/zdd: N := 8
 combinatorial/queens/zdd:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_queens_zdd) -N $(N) -M $(M)
+	@$(subst VARIANT,$(V),./build/src/VARIANT_queens_zdd) -N $(N) -M $(M) | tee -a queens_zdd.out
 
 combinatorial/queens/bdd: N := 8
 combinatorial/queens/bdd:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_queens) -N $(N) -M $(M)
+	@$(subst VARIANT,$(V),./build/src/VARIANT_queens) -N $(N) -M $(M) | tee -a queens_bdd.out
 
 combinatorial/tic_tac_toe: N := 20
 combinatorial/tic_tac_toe:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_tic_tac_toe) -N $(N) -M $(M)
+	@$(subst VARIANT,$(V),./build/src/VARIANT_tic_tac_toe) -N $(N) -M $(M) | tee -a tic_tac_toe.out
 
 sat-solver/pigeonhole_principle: N := 10
 sat-solver/pigeonhole_principle:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_pigeonhole_principle) -N $(N) -M $(M)
+	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_pigeonhole_principle) -N $(N) -M $(M) | tee -a sat__pigeon.out
 
 sat-solver/queens: N := 6
 sat-solver/queens:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_queens) -N $(N) -M $(M)
+	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_queens) -N $(N) -M $(M) | tee -a sat__queens_bdd.out

--- a/makefile
+++ b/makefile
@@ -61,10 +61,7 @@ F1 := ""
 F2 := ""
 O := "INPUT"
 
-combinatorial/picotrav:
-combinatorial/picotrav:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_picotrav) -f $(F1) -f $(F2) -M $(M) -o $(O) | tee -a picotrav.out
-
+# Combinatorial Problems
 combinatorial/queens:
 	$(MAKE) combinatorial/queens/bdd
 
@@ -80,6 +77,7 @@ combinatorial/tic_tac_toe: N := 20
 combinatorial/tic_tac_toe:
 	@$(subst VARIANT,$(V),./build/src/VARIANT_tic_tac_toe) -N $(N) -M $(M) | tee -a tic_tac_toe.out
 
+# Sat Solver problems
 sat-solver/pigeonhole_principle: N := 10
 sat-solver/pigeonhole_principle:
 	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_pigeonhole_principle) -N $(N) -M $(M) | tee -a sat__pigeon.out
@@ -87,3 +85,8 @@ sat-solver/pigeonhole_principle:
 sat-solver/queens: N := 6
 sat-solver/queens:
 	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_queens) -N $(N) -M $(M) | tee -a sat__queens_bdd.out
+
+# Verification problems
+verification/picotrav:
+verification/picotrav:
+	@$(subst VARIANT,$(V),./build/src/VARIANT_picotrav) -f $(F1) -f $(F2) -M $(M) -o $(O) | tee -a picotrav.out

--- a/makefile
+++ b/makefile
@@ -31,9 +31,13 @@ build:
 														&& make MAKEINFO=true \
 														&& make install)
 
+  # Make out folder
+	@mkdir -p out/
+
   # Build all bdd benchmarks
 	@echo "\n\nBuild BDD Benchmarks"
 	@cd build/ && for package in 'adiar' 'buddy' 'sylvan' 'cudd' ; do \
+		mkdir -p ../out/$$package ; \
 		for benchmark in 'picotrav' 'queens' 'sat_pigeonhole_principle' 'sat_queens' 'tic_tac_toe' ; do \
 			make ${MAKE_FLAGS} $$package'_'$$benchmark ; \
 		done ; \
@@ -42,6 +46,7 @@ build:
   # Build all zdd benchmarks
 	@echo "\n\nBuild ZDD Benchmarks"
 	@cd build/ && for package in 'adiar' ; do \
+		mkdir -p ../out/$$package ; \
 		for benchmark in 'queens_zdd' ; do \
 			make ${MAKE_FLAGS} $$package'_'$$benchmark ; \
 		done ; \
@@ -53,40 +58,47 @@ build:
 clean:
 	@cd external/cudd && git clean -qdf && git checkout .
 	@rm -rf build/
+	@rm -rf out/
+
+clean/out:
+	@rm out/**/*.out
 
 # ============================================================================ #
-#  RUN TARGETS
+#  COMBINATORIAL PROBLEMS
+# ============================================================================ #
+combinatorial/queens:
+	$(MAKE) combinatorial/queens/bdd
+
+combinatorial/queens/bdd: N := 8
+combinatorial/queens/bdd:
+	@$(subst VARIANT,$(V),./build/src/VARIANT_queens -N $(N) -M $(M) | tee -a out/VARIANT/queens.out)
+
+combinatorial/queens/zdd: N := 8
+combinatorial/queens/zdd:
+	@$(subst VARIANT,$(V),./build/src/VARIANT_queens_zdd -N $(N) -M $(M) | tee -a out/VARIANT/queens_zdd.out)
+
+combinatorial/tic_tac_toe: N := 20
+combinatorial/tic_tac_toe:
+	@$(subst VARIANT,$(V),./build/src/VARIANT_tic_tac_toe -N $(N) -M $(M) | tee -a out/VARIANT/tic_tac_toe.out)
+
+# ============================================================================ #
+#  SAT SOLVER
+# ============================================================================ #
+sat-solver/pigeonhole_principle: N := 10
+sat-solver/pigeonhole_principle:
+	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_pigeonhole_principle -N $(N) -M $(M) | tee -a out/VARIANT/sat_pigeonhole_principle.out)
+
+sat-solver/queens: N := 6
+sat-solver/queens:
+	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_queens -N $(N) -M $(M) | tee -a out/VARIANT/sat_queens.out)
+
+# ============================================================================ #
+#  VERIFICATION BENCHMARKS
 # ============================================================================ #
 F1 := ""
 F2 := ""
 O := "INPUT"
 
-# Combinatorial Problems
-combinatorial/queens:
-	$(MAKE) combinatorial/queens/bdd
-
-combinatorial/queens/zdd: N := 8
-combinatorial/queens/zdd:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_queens_zdd) -N $(N) -M $(M) | tee -a queens_zdd.out
-
-combinatorial/queens/bdd: N := 8
-combinatorial/queens/bdd:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_queens) -N $(N) -M $(M) | tee -a queens_bdd.out
-
-combinatorial/tic_tac_toe: N := 20
-combinatorial/tic_tac_toe:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_tic_tac_toe) -N $(N) -M $(M) | tee -a tic_tac_toe.out
-
-# Sat Solver problems
-sat-solver/pigeonhole_principle: N := 10
-sat-solver/pigeonhole_principle:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_pigeonhole_principle) -N $(N) -M $(M) | tee -a sat__pigeon.out
-
-sat-solver/queens: N := 6
-sat-solver/queens:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_sat_queens) -N $(N) -M $(M) | tee -a sat__queens_bdd.out
-
-# Verification problems
 verification/picotrav:
 verification/picotrav:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_picotrav) -f $(F1) -f $(F2) -M $(M) -o $(O) | tee -a picotrav.out
+	@$(subst VARIANT,$(V),./build/src/VARIANT_picotrav -f $(F1) -f $(F2) -M $(M) -o $(O) | tee -a out/VARIANT/picotrav.out)


### PR DESCRIPTION
This makes it easier to collect benchmarks locally. It essentially brings parts of the *grendel* scripts to the Makefile. I also reclassified Picotrav as a verification benchmark.