### PR TITLE
ZDD/Knight's tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ one to compare implementations.
     - [Dependencies](#dependencies)
     - [Usage](#usage)
     - [Combinatorial Benchmarks](#combinatorial-benchmarks)
+        - [Knight's Tour](#knights-tour)
         - [Queens](#queens)
         - [Tic-Tac-Toe](#tic-tac-toe)
     - [SAT Solver Benchmarks](#sat-solver-benchmarks)
@@ -151,6 +152,42 @@ make combinatorial/queens V=cudd N=10 M=256
 
 
 ## Combinatorial Benchmarks
+
+### Knight's Tour
+Solves the following problem:
+
+> Given N, then how many hamiltonian paths can a single Knight do across a chess
+> board of size (N/2)x(N-N/2)?
+
+Our implementation is based on Bryants implementation
+[here](https://github.com/rebryant/Cloud-BDD/blob/conjunction_streamlined/hamiltonian/hpath.py)
+using ZDDs. We represent all O(N<sup>4</sup>) states, i.e. position and time, as
+a separate variable; a transition relation then encodes the legal moves between
+two time steps. By intersecting moves at all time steps we obtain all paths.
+On-top of this, hamiltonian constraints are added and finally the size of the
+set of Knight's Tours is obtained.
+
+You may choose to include the hamiltonian constraint inside of the transition
+relation. This seems to result in slower running times, but slightly smaller
+ZDDs.
+
+You may provide an option `-o` of the form `{STRAT}_{TYPE}`
+
+- `{STRAT}`: Whether to use the `SPLIT` approach, where transitions and
+  hamiltonian are handled separately. Alternatively, one may use the `COMBINED`
+  approach.
+
+- `{TYPE}`: Whether to count the `OPEN` paths, i.e. all hamiltonian paths, or
+  only the `CLOSED` ones, i.e. the hamiltonian cycles.
+
+`OPEN` and `CLOSED` are shortcuts for using `SPLIT`.
+
+**Statistics:**
+
+| Variable                | Value         |
+|-------------------------|---------------|
+| Labels                  | N<sup>4</sup> |
+| Intersection operations | 4<sup>4</sup> |
 
 ### Queens
 Solves the following problem:

--- a/makefile
+++ b/makefile
@@ -47,7 +47,7 @@ build:
 	@echo "\n\nBuild ZDD Benchmarks"
 	@cd build/ && for package in 'adiar' ; do \
 		mkdir -p ../out/$$package ; \
-		for benchmark in 'queens_zdd' ; do \
+		for benchmark in 'queens_zdd' 'knights_tour_zdd' ; do \
 			make ${MAKE_FLAGS} $$package'_'$$benchmark ; \
 		done ; \
 	done
@@ -66,6 +66,13 @@ clean/out:
 # ============================================================================ #
 #  COMBINATORIAL PROBLEMS
 # ============================================================================ #
+combinatorial/knights_tour:
+	$(MAKE) combinatorial/knights_tour/zdd
+
+combinatorial/knights_tour/zdd: N := 12
+combinatorial/knights_tour/zdd:
+	@$(subst VARIANT,$(V),./build/src/VARIANT_knights_tour_zdd -N $(N) -M $(M) | tee -a out/VARIANT/queens_zdd.out)
+
 combinatorial/queens:
 	$(MAKE) combinatorial/queens/bdd
 

--- a/makefile
+++ b/makefile
@@ -66,12 +66,15 @@ clean/out:
 # ============================================================================ #
 #  COMBINATORIAL PROBLEMS
 # ============================================================================ #
+O := ""
+
 combinatorial/knights_tour:
 	$(MAKE) combinatorial/knights_tour/zdd
 
 combinatorial/knights_tour/zdd: N := 12
+combinatorial/knights_tour/zdd: O="OPEN"
 combinatorial/knights_tour/zdd:
-	@$(subst VARIANT,$(V),./build/src/VARIANT_knights_tour_zdd -N $(N) -M $(M) | tee -a out/VARIANT/queens_zdd.out)
+	@$(subst VARIANT,$(V),./build/src/VARIANT_knights_tour_zdd -N $(N) -M $(M) -o $(O) | tee -a out/VARIANT/queens_zdd.out)
 
 combinatorial/queens:
 	$(MAKE) combinatorial/queens/bdd
@@ -107,8 +110,7 @@ sat-solver/queens:
 # ============================================================================ #
 F1 := ""
 F2 := ""
-O := "INPUT"
 
-verification/picotrav:
+verification/picotrav: O := "INPUT"
 verification/picotrav:
 	@$(subst VARIANT,$(V),./build/src/VARIANT_picotrav -f $(F1) -f $(F2) -M $(M) -o $(O) | tee -a out/VARIANT/picotrav.out)

--- a/makefile
+++ b/makefile
@@ -77,8 +77,11 @@ combinatorial/queens/zdd: N := 8
 combinatorial/queens/zdd:
 	@$(subst VARIANT,$(V),./build/src/VARIANT_queens_zdd -N $(N) -M $(M) | tee -a out/VARIANT/queens_zdd.out)
 
-combinatorial/tic_tac_toe: N := 20
 combinatorial/tic_tac_toe:
+	$(MAKE) combinatorial/queens/bdd
+
+combinatorial/tic_tac_toe/bdd: N := 20
+combinatorial/tic_tac_toe/bdd:
 	@$(subst VARIANT,$(V),./build/src/VARIANT_tic_tac_toe -N $(N) -M $(M) | tee -a out/VARIANT/tic_tac_toe.out)
 
 # ============================================================================ #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,9 +37,6 @@ endmacro(link_extra)
 
 # ---------------------------------------------------------------------------- #
 # Combinatorial Benchmarks
-add_bdd_benchmark(picotrav)
-link_extra(picotrav libblifparse)
-
 add_bdd_benchmark(queens)
 add_zdd_benchmark(queens_zdd)
 
@@ -50,3 +47,8 @@ add_bdd_benchmark(tic_tac_toe)
 add_bdd_benchmark(sat_pigeonhole_principle)
 
 add_bdd_benchmark(sat_queens)
+
+# ---------------------------------------------------------------------------- #
+# Verification
+add_bdd_benchmark(picotrav)
+link_extra(picotrav libblifparse)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,8 @@ add_zdd_benchmark(queens_zdd)
 
 add_bdd_benchmark(tic_tac_toe)
 
+add_zdd_benchmark(knights_tour_zdd)
+
 # ---------------------------------------------------------------------------- #
 # SAT Solver benchmarks
 add_bdd_benchmark(sat_pigeonhole_principle)

--- a/src/adiar/knights_tour_zdd.cpp
+++ b/src/adiar/knights_tour_zdd.cpp
@@ -150,9 +150,12 @@ inline void __knights_tour_rel__post_chain<false>(adiar::node_writer &out_writer
 {
   // Simple "don't care" chain
   const int this_label = int_of_position(row, col, time);
-  const adiar::ptr_t next_ptr = this_label == MAX_POSITION()
+  const int max_reachable = MAX_POSITION();
+  const int next_reachable = next_reachable_position(row, col, time);
+
+  const adiar::ptr_t next_ptr = this_label == max_reachable
     ? adiar::create_sink_ptr(true)
-    : adiar::create_node_ptr(this_label+1, 0);
+    : adiar::create_node_ptr(next_reachable, 0);
 
   out_writer << adiar::create_node(this_label, 0, next_ptr, next_ptr);
 }

--- a/src/adiar/knights_tour_zdd.cpp
+++ b/src/adiar/knights_tour_zdd.cpp
@@ -1,0 +1,167 @@
+#include "../knights_tour.cpp"
+
+#include "zdd_adapter.h"
+
+// ========================================================================== //
+//                 Transition Relation + Hamiltonian Constraint               //
+adiar::ptr_t first_legal(int r_from, int c_from, int t)
+{
+  for (int idx = 0; idx < 8; idx++) {
+    const int r_to = r_from + row_moves[idx];
+    const int c_to = c_from + column_moves[idx];
+
+    if (!is_legal_position(r_to, c_to)) { continue; }
+
+    const adiar::label_t to_label = int_of_position(r_to, c_to, t);
+    const adiar::label_t chain_id = int_of_position(r_from, c_from);
+
+    return adiar::create_node_ptr(to_label, chain_id);
+  }
+  return adiar::create_sink_ptr(false);
+}
+
+adiar::ptr_t next_legal(int r_from, int c_from, int r_to, int c_to, int t)
+{
+  bool seen_move = false;
+
+  for (int idx = 0; idx < 8; idx++) {
+    const int r = r_from + row_moves[idx];
+    const int c = c_from + column_moves[idx];
+
+    if (!is_legal_position(r,c)) { continue; }
+
+    if (seen_move) {
+      const adiar::label_t to_label = int_of_position(r, c, t);
+      const adiar::id_t chain_id = int_of_position(r_from, c_from);
+
+      return adiar::create_node_ptr(to_label, chain_id);
+    }
+    seen_move |= r == r_to && c == c_to;
+  }
+  return adiar::create_sink_ptr(false);
+}
+
+template<>
+adiar::zdd knights_tour_rel(adiar_zdd_adapter &/*adapter*/, int t) {
+  INFO("t = %i\n", t);
+
+  adiar::node_file out;
+  adiar::node_writer out_writer(out);
+
+  // Time steps t' > t+1:
+  //   Hamiltonian constraint chain for each position reached at time step 't+1'
+  //   given some position at time step 't'.
+  //
+  //   TODO: We do not share subtrees at the bottom-most level, despite the last
+  //   time step definitely does share the last few variables. To fix this, we
+  //   need to collapse to the '0' chain_id if beyond (row_t,col_t).
+  for (int time = MAX_TIME(); time > t+1; time--) {
+    for (int row = MAX_ROW(); row >= 0; row--) {
+      for (int col = MAX_COL(); col >= 0; col--) {
+        for (int row_t = MAX_ROW(); row_t >= 0; row_t--) {
+          for (int col_t = MAX_COL(); col_t >= 0; col_t--) {
+            // This position matches (row_t, col_t)? Skip it to make this chain
+            // enforce it being a hamiltonian path.
+            if (row_t == row && col_t == col) { continue; }
+
+            const adiar::label_t this_label = int_of_position(row, col, time);
+            const adiar::id_t this_id = int_of_position(row_t, col_t);
+
+            // Find next label, that does match (row_t, col_t)
+            const int this_conflict = int_of_position(row_t, col_t, time);
+            const int next_conflict = int_of_position(row_t, col_t, time+1);
+
+            int next_label = this_label+1;
+            if (next_label == this_conflict) { next_label++; }
+            if (next_label == next_conflict) { next_label++; }
+
+            const adiar::ptr_t child = next_label > MAX_POSITION()
+              ? adiar::create_sink_ptr(true)
+              : adiar::create_node_ptr(next_label, this_id);
+
+            out_writer << adiar::create_node(this_label, this_id, child, child);
+          }
+        }
+      }
+    }
+  }
+
+  // Time-step t+1:
+  //   Chain with each possible position reachable from some position at time 't'.
+  for (int row = MAX_ROW(); row >= 0; row--) {
+    for (int col = MAX_COL(); col >= 0; col--) {
+      for (int row_t = MAX_ROW(); row_t >= 0; row_t--) {
+        for (int col_t = MAX_COL(); col_t >= 0; col_t--) {
+          if (!is_legal_move(row_t, col_t, row, col)) { continue; }
+
+          const adiar::label_t this_label = int_of_position(row, col, t+1);
+          const adiar::id_t chain_id = int_of_position(row_t, col_t);
+
+          const adiar::ptr_t next_this_chain = next_legal(row_t, col_t, row, col, t+1);
+
+          int hamiltonian_legal_root = int_of_position(0, 0, t+2);
+          if (row_t == 0 && col_t == 0) { hamiltonian_legal_root++; }
+
+          const adiar::ptr_t hamiltonian_root = t+1 == MAX_TIME()
+            ? adiar::create_sink_ptr(true)
+            : adiar::create_node_ptr(hamiltonian_legal_root, chain_id);
+
+          out_writer << adiar::create_node(this_label, chain_id,
+                                           next_this_chain,
+                                           hamiltonian_root);
+        }
+      }
+    }
+  }
+
+  // Time-step t:
+  //   For each position at time step 't', check whether we are "here" and go to
+  //   the chain checking "where we go to" at 't+1'.
+  adiar::ptr_t root = adiar::create_sink_ptr(false);
+
+  for (int row = MAX_ROW(); row >= 0; row--) {
+    for (int col = MAX_COL(); col >= 0; col--) {
+      const adiar::label_t this_label = int_of_position(row, col, t);
+      const adiar::ptr_t move_chain = first_legal(row, col, t+1);
+
+      const adiar::node_t n = adiar::create_node(this_label, 0, root, move_chain);
+      root = n.uid;
+      out_writer << n;
+   }
+  }
+
+  // Time-step t' < t:
+  //   Just allow everything, i.e. add no constraints
+  if (t > 0) {
+    for (int pos = int_of_position(MAX_ROW(), MAX_COL(), t-1); pos >= 0; pos--) {
+      adiar::node_t n = adiar::create_node(pos, 0, root, root);
+      root = n.uid;
+      out_writer << n;
+    }
+  }
+
+  const size_t nodecount = out_writer.size();
+  largest_bdd = std::max(largest_bdd, nodecount);
+  total_nodes += nodecount;
+
+  return out;
+}
+
+template<>
+adiar::zdd knights_tour_rel(adiar_zdd_adapter &/*adapter*/, int t)
+{
+  return __knights_tour_rel<false>(t);
+}
+
+template<>
+adiar::zdd knights_tour_ham_rel(adiar_zdd_adapter &/*adapter*/, int t)
+{
+  return __knights_tour_rel<true>(t);
+}
+
+
+// ========================================================================== //
+int main(int argc, char** argv)
+{
+  run_knights_tour<adiar_zdd_adapter>(argc, argv);
+}

--- a/src/adiar/knights_tour_zdd.cpp
+++ b/src/adiar/knights_tour_zdd.cpp
@@ -126,11 +126,12 @@ inline void __knights_tour_rel__post_chain<true>(adiar::node_writer &out_writer,
       //
       // For the id, we will collapse into the 0-chain if we are past
       // the final time to check for the hamiltonian constraint.
-      int next_label = this_label+1;
+      int next_label = next_reachable_position(row, col, time);
       if (next_label == this_conflict) { next_label++; }
       if (next_label == next_conflict) { next_label++; }
+      if (!is_reachable(row_of_position(next_label), col_of_position(next_label))) { next_label++; }
 
-      const int next_id = (MAX_TIME() == time   && next_label > this_conflict)
+      const int next_id = (MAX_TIME() == time && next_label > this_conflict)
         || (MAX_TIME()-1 == time && next_label > next_conflict)
         ? 0
         : this_id;

--- a/src/adiar/knights_tour_zdd.cpp
+++ b/src/adiar/knights_tour_zdd.cpp
@@ -3,6 +3,56 @@
 #include "zdd_adapter.h"
 
 // ========================================================================== //
+//                          Closed Tour Constraints                           //
+template<>
+adiar::zdd knights_tour_closed(adiar_zdd_adapter &/*adapter*/)
+{
+  adiar::node_file out;
+  adiar::node_writer out_writer(out);
+
+  // Fix t = MAX_TIME() to be (1,2)
+  const int stepMax_position = int_of_position(closed_squares[2][0], closed_squares[2][1], MAX_TIME());
+  const adiar::node_t stepMax_state = adiar::create_node(stepMax_position, 0,
+                                                         adiar::create_sink_ptr(false),
+                                                         adiar::create_sink_ptr(true));
+  out_writer << stepMax_state;
+
+  adiar::ptr_t root = stepMax_state.uid;
+
+  // All in between is as-is but takes the hamiltonian constraint into account.
+  for (int t = MAX_TIME() - 1; t > 1; t--) {
+    for (int r = MAX_ROW(); r >= 0; r--) {
+      for (int c = MAX_COL(); c >= 0; c--) {
+        if (is_closed_square(r,c)) { continue; }
+
+        const adiar::node_t n = adiar::create_node(int_of_position(r,c,t), 0, root, root);
+        out_writer << n;
+
+        root = n.uid;
+      }
+    }
+  }
+
+  // Fix t = 1 to be (2,1)
+  const int step1_position = int_of_position(closed_squares[1][0], closed_squares[1][1], 1);
+  const adiar::node_t step1_state = adiar::create_node(step1_position, 0, root, root);
+  out_writer << step1_state;
+
+  root = step1_state.uid;
+
+  // Fix t = 0 to be (0,0)
+  const int step0_position = int_of_position(closed_squares[0][0], closed_squares[0][1], 0);
+  const adiar::node_t step0_state = adiar::create_node(step0_position, 0, root, root);
+  out_writer << step0_state;
+
+  const size_t nodecount = out_writer.size();
+  largest_bdd = std::max(largest_bdd, nodecount);
+  total_nodes += nodecount;
+
+  return out;
+}
+
+// ========================================================================== //
 //                 Transition Relation + Hamiltonian Constraint               //
 adiar::ptr_t first_legal(int r_from, int c_from, int t)
 {
@@ -42,45 +92,105 @@ adiar::ptr_t next_legal(int r_from, int c_from, int r_to, int c_to, int t)
 }
 
 template<>
-adiar::zdd knights_tour_rel(adiar_zdd_adapter &/*adapter*/, int t) {
-  INFO("t = %i\n", t);
+adiar::zdd knights_tour_ham(adiar_zdd_adapter &/*adapter*/, int r, int c)
+{
+  adiar::node_file out;
+  adiar::node_writer out_writer(out);
 
+  adiar::ptr_t root_never = adiar::create_sink_ptr(false);
+  adiar::ptr_t root_once = adiar::create_sink_ptr(true);
+
+  for (int this_t = MAX_TIME(); this_t >= 0; this_t--) {
+    for (int this_r = MAX_ROW(); this_r >= 0; this_r--) {
+      for (int this_c = MAX_COL(); this_c >= 0; this_c--) {
+        int this_label = int_of_position(this_r, this_c, this_t);
+
+        bool is_rc = r == this_r && c == this_c;
+
+        if (!is_rc && (this_t > 0 || this_r > r)) {
+          adiar::node_t out_once = adiar::create_node(this_label, 1, root_once, root_once);
+          out_writer << out_once;
+          root_once = out_once.uid;
+        }
+
+        adiar::node_t out_never = adiar::create_node(this_label, 0,
+                                                     root_never,
+                                                     is_rc ? root_once : root_never);
+        out_writer << out_never;
+        root_never = out_never.uid;
+      }
+    }
+  }
+
+  const size_t nodecount = out_writer.size();
+  largest_bdd = std::max(largest_bdd, nodecount);
+  total_nodes += nodecount;
+
+  return out;
+}
+
+template<bool ham_rel>
+inline adiar::zdd __knights_tour_rel(int t)
+{
   adiar::node_file out;
   adiar::node_writer out_writer(out);
 
   // Time steps t' > t+1:
   //   Hamiltonian constraint chain for each position reached at time step 't+1'
   //   given some position at time step 't'.
-  //
-  //   TODO: We do not share subtrees at the bottom-most level, despite the last
-  //   time step definitely does share the last few variables. To fix this, we
-  //   need to collapse to the '0' chain_id if beyond (row_t,col_t).
   for (int time = MAX_TIME(); time > t+1; time--) {
     for (int row = MAX_ROW(); row >= 0; row--) {
       for (int col = MAX_COL(); col >= 0; col--) {
-        for (int row_t = MAX_ROW(); row_t >= 0; row_t--) {
-          for (int col_t = MAX_COL(); col_t >= 0; col_t--) {
-            // This position matches (row_t, col_t)? Skip it to make this chain
-            // enforce it being a hamiltonian path.
-            if (row_t == row && col_t == col) { continue; }
+        if (!is_reachable(row, col)) { continue; }
 
-            const adiar::label_t this_label = int_of_position(row, col, time);
-            const adiar::id_t this_id = int_of_position(row_t, col_t);
+        const int this_label = int_of_position(row, col, time);
 
-            // Find next label, that does match (row_t, col_t)
-            const int this_conflict = int_of_position(row_t, col_t, time);
-            const int next_conflict = int_of_position(row_t, col_t, time+1);
+        if constexpr (ham_rel) {
+          for (int row_t = MAX_ROW(); row_t >= 0; row_t--) {
+            for (int col_t = MAX_COL(); col_t >= 0; col_t--) {
+              // This position matches (row_t, col_t)? Skip it to make this
+              // chain enforce it being a hamiltonian path.
+              if (row_t == row && col_t == col) { continue; }
 
-            int next_label = this_label+1;
-            if (next_label == this_conflict) { next_label++; }
-            if (next_label == next_conflict) { next_label++; }
+              // Missing node for this and the next time step
+              const int this_conflict = int_of_position(row_t, col_t, time);
+              const int next_conflict = int_of_position(row_t, col_t, time+1);
 
-            const adiar::ptr_t child = next_label > MAX_POSITION()
-              ? adiar::create_sink_ptr(true)
-              : adiar::create_node_ptr(next_label, this_id);
+              // If past this time step's conflict, then do not output
+              // something, since we will merge with the (0,0) chain
+              if (time == MAX_TIME() && this_label > this_conflict && !(row_t == 0 && col_t == 0)) {
+                continue;
+              }
 
-            out_writer << adiar::create_node(this_label, this_id, child, child);
+              const int this_id = int_of_position(row_t, col_t);
+
+              // Next cell on board this time step that does match (row_t,col_t).
+              // Possibly loops back to (0,0) at the next time step.
+              //
+              // For the id, we will collapse into the 0-chain if we are past
+              // the final time to check for the hamiltonian constraint.
+              int next_label = this_label+1;
+              if (next_label == this_conflict) { next_label++; }
+              if (next_label == next_conflict) { next_label++; }
+
+              const int next_id = (MAX_TIME() == time   && next_label > this_conflict)
+                || (MAX_TIME()-1 == time && next_label > next_conflict)
+                ? 0
+                : this_id;
+
+              const adiar::ptr_t child = next_label > MAX_POSITION()
+                ? adiar::create_sink_ptr(true)
+                : adiar::create_node_ptr(next_label, next_id);
+
+              out_writer << adiar::create_node(this_label, this_id, child, child);
+            }
           }
+        } else { // !ham_rel
+          const adiar::ptr_t next_ptr = this_label == MAX_POSITION()
+            ? adiar::create_sink_ptr(true)
+            : adiar::create_node_ptr(this_label+1, 0);
+
+          out_writer << adiar::create_node(this_label, 0, next_ptr, next_ptr);
         }
       }
     }
@@ -94,21 +204,30 @@ adiar::zdd knights_tour_rel(adiar_zdd_adapter &/*adapter*/, int t) {
         for (int col_t = MAX_COL(); col_t >= 0; col_t--) {
           if (!is_legal_move(row_t, col_t, row, col)) { continue; }
 
-          const adiar::label_t this_label = int_of_position(row, col, t+1);
-          const adiar::id_t chain_id = int_of_position(row_t, col_t);
+          const int this_label = int_of_position(row, col, t+1);
+          const int chain_id = int_of_position(row_t, col_t);
 
           const adiar::ptr_t next_this_chain = next_legal(row_t, col_t, row, col, t+1);
 
-          int hamiltonian_legal_root = int_of_position(0, 0, t+2);
-          if (row_t == 0 && col_t == 0) { hamiltonian_legal_root++; }
+          adiar::ptr_t chain_root = adiar::NIL;
+          if constexpr (ham_rel) {
+            int hamiltonian_legal_root = int_of_position(0, 0, t+2);
+            if (row_t == 0 && col_t == 0) { hamiltonian_legal_root++; }
 
-          const adiar::ptr_t hamiltonian_root = t+1 == MAX_TIME()
-            ? adiar::create_sink_ptr(true)
-            : adiar::create_node_ptr(hamiltonian_legal_root, chain_id);
+            const int hamiltonian_legal_id = hamiltonian_legal_root > int_of_position(row_t, col_t, MAX_TIME())
+              ? 0
+              : chain_id;
 
-          out_writer << adiar::create_node(this_label, chain_id,
-                                           next_this_chain,
-                                           hamiltonian_root);
+            chain_root = t+1 == MAX_TIME()
+              ? adiar::create_sink_ptr(true)
+              : adiar::create_node_ptr(hamiltonian_legal_root, hamiltonian_legal_id);
+          } else { // !ham_rel
+            chain_root = t+1 == MAX_TIME()
+              ? adiar::create_sink_ptr(true)
+              : adiar::create_node_ptr(int_of_position(0,0,t+2), 0);
+          }
+
+          out_writer << adiar::create_node(this_label, chain_id, next_this_chain, chain_root);
         }
       }
     }

--- a/src/adiar/knights_tour_zdd.cpp
+++ b/src/adiar/knights_tour_zdd.cpp
@@ -259,13 +259,15 @@ inline adiar::zdd knights_tour_rel(int t)
 template<>
 adiar::zdd knights_tour_rel<adiar_zdd_adapter, false>(adiar_zdd_adapter &/*adapter*/, int t)
 {
-  return knights_tour_rel<false>(t);
+  const adiar::zdd res = knights_tour_rel<false>(t);
+  return res;
 }
 
 template<>
 adiar::zdd knights_tour_rel<adiar_zdd_adapter, true>(adiar_zdd_adapter &/*adapter*/, int t)
 {
-  return knights_tour_rel<true>(t);
+  const adiar::zdd res = knights_tour_rel<true>(t);
+  return res;
 }
 
 // ========================================================================== //

--- a/src/adiar/zdd_adapter.h
+++ b/src/adiar/zdd_adapter.h
@@ -27,6 +27,9 @@ public:
 
   // ZDD Operations
 public:
+  inline adiar::zdd ithvar(int i)
+  { return adiar::zdd_ithvar(i); }
+
   inline uint64_t nodecount(const adiar::zdd &z)
   { return adiar::zdd_nodecount(z); }
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -50,21 +50,28 @@ std::string temp_path = "";
 
 std::vector<std::string> input_files = {};
 
-enum no_variable_order { NO_ORDERING };
+template<typename option_enum>
+option_enum parse_option(const std::string &arg, bool &should_exit);
 
-template<typename variable_order_enum>
-variable_order_enum parse_variable_ordering(const std::string &arg, bool &should_exit);
+template<typename option_enum>
+std::string option_help_str();
+
+enum no_options { NONE };
 
 template<>
-no_variable_order parse_variable_ordering(const std::string &, bool &should_exit)
+no_options parse_option(const std::string &, bool &should_exit)
 {
   ERROR("Variable ordering is undefined for this benchmark\n");
   should_exit = true;
-  return no_variable_order::NO_ORDERING;
+  return no_options::NONE;
 }
 
-template<typename variable_order_enum = no_variable_order>
-bool parse_input(int &argc, char* argv[], variable_order_enum &variable_order)
+template<>
+std::string option_help_str<no_options>()
+{ return "Not part of this benchmark"; }
+
+template<typename option_enum = no_options>
+bool parse_input(int &argc, char* argv[], option_enum &option)
 {
   bool exit = false;
   int c;
@@ -93,7 +100,7 @@ bool parse_input(int &argc, char* argv[], variable_order_enum &variable_order)
       }
 
       case 'o':
-        variable_order = parse_variable_ordering<variable_order_enum>(optarg, exit);
+        option = parse_option<option_enum>(optarg, exit);
         continue;
 
       case 't':
@@ -112,7 +119,7 @@ bool parse_input(int &argc, char* argv[], variable_order_enum &variable_order)
                                         << "]       Size of a problem" << std::endl
                   << "        -f FILENAME           Input file to run (use repeatedly for multiple files)" << std::endl
                   << "        -M MiB      [128]     Amount of memory (MiB) to be dedicated to the BDD package" << std::endl
-                  << "        -o ORDERING           Variable ordering to use" << std::endl
+                  << "        -o OPTION             " << option_help_str<option_enum>() << std::endl
                   << "        -t TEMP_PTH [/tmp]    Filepath for temporary files on disk" << std::endl
           ;
         return true;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -19,6 +19,8 @@ inline time_point get_timestamp() {
   return std::chrono::steady_clock::now();
 }
 
+typedef unsigned long int time_duration;
+
 inline unsigned long int duration_of(const time_point &before, const time_point &after) {
   return std::chrono::duration_cast<std::chrono::milliseconds>(after - before).count();
 }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -7,7 +7,7 @@
 constexpr size_t CACHE_RATIO = 64u;
 
 // Initial size taken from CUDD defaults
-constexpr size_t INIT_UNIQUE_SLOTS_PER_VAR = 256;
+constexpr size_t INIT_UNIQUE_SLOTS_PER_VAR = 256u;
 
 // =============================================================================
 // A few chrono wrappers to improve readability

--- a/src/expected.h
+++ b/src/expected.h
@@ -1,3 +1,53 @@
+constexpr size_t UNKNOWN = static_cast<size_t>(-1);
+
+// =============================================================================
+// Knight's Tour Problem
+//
+// expected number taken from:
+// [1] https://oeis.org/search?q=knights+tour
+// [2] https://en.wikipedia.org/wiki/Knight%27s_tour#Number_of_tours
+// [3] Our own numbers
+const size_t expected_knights_tour_open[17] = {
+  0,
+  0,
+  1,                // 1x1 [2]
+  0,                // 2x1 [3]
+  0,                // 2x2 [2]
+  0,                // 3x2 [1]
+  0,                // 3x3 [2]
+  16,               // 4x3 [1]
+  0,                // 4x4 [2]
+  164,              // 5x4 [3]
+  1728,             // 5x5 [2]
+  37568,            // 6x5 [3]
+  6637920,          // 6x6 [2]
+  UNKNOWN,          // 7x6 [?]
+  165575218320,     // 7x7 [2]
+  UNKNOWN,          // 8x7 [?]
+  19591828170979904 // 8x8 [2]
+};
+
+const size_t expected_knights_tour_closed[17] = {
+  0,
+  0,
+  1,                // 1x1 [1]
+  0,                // 2x1 [3]
+  0,                // 2x2 [2]
+  0,                // 3x2 [3]
+  0,                // 3x3 [1]
+  0,                // 4x3 [3]
+  0,                // 4x4 [1]
+  0,                // 5x4 [3]
+  0,                // 5x5 [1]
+  UNKNOWN,          // 6x5 [?]
+  9862,             // 6x6 [2]
+  UNKNOWN,          // 7x6 [?]
+  0,                // 7x7 [1]
+  UNKNOWN,          // 8x7 [?]
+  13267364410532    // 8x8 [1]
+};
+
+
 // =============================================================================
 // Queens Problem
 //

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -1,4 +1,5 @@
 #include "common.cpp"
+#include "expected.h"
 
 size_t largest_bdd = 0;
 size_t total_nodes = 0;
@@ -272,10 +273,14 @@ void run_knights_tour(int argc, char** argv)
 
   adapter.print_stats();
 
-  /* TODO
-  if (N < size(expected_queens) && solutions != expected_queens[N]) {
+  if (!closed && N < size(expected_knights_tour_open)
+      && expected_knights_tour_open[N] != UNKNOWN && solutions != expected_knights_tour_open[N]) {
     EXIT(-1);
   }
-  */
+
+  if (closed && N < size(expected_knights_tour_closed)
+      && expected_knights_tour_closed[N] != UNKNOWN && solutions != expected_knights_tour_closed[N]) {
+    EXIT(-1);
+  }
   FLUSH();
 }

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -185,11 +185,6 @@ void run_knights_tour(int argc, char** argv)
   bool should_exit = parse_input(argc, argv, opt);
   if (should_exit) { exit(-1); }
 
-  if (rows() == 0 || cols() == 0) {
-    ERROR("  Please provide an N > 1 (-N)\n");
-    exit(-1);
-  }
-
   closed  = opt == iter_opt::SPLIT_CLOSED || opt == iter_opt::COMBINED_CLOSED;
   ham_rel = opt == iter_opt::COMBINED_OPEN || opt == iter_opt::COMBINED_CLOSED;
 
@@ -197,6 +192,17 @@ void run_knights_tour(int argc, char** argv)
   INFO("%i x %i - Knight's Tour (%s %i MiB):\n", rows(), cols(), adapter_t::NAME.c_str(), M);
   INFO("   | Tour type:              %s\n", closed ? "Closed tours only" : "Open (all) tours");
   INFO("   | Computation pattern:    Transitions %s Hamiltonian\n", ham_rel ? "||" : ";");
+
+  if (rows() == 0 || cols() == 0) {
+    INFO("\n  The board has no cells. Please provide an N > 1 (-N)\n");
+    exit(0);
+  }
+
+  if (closed && (rows() < 3 || cols() < 3) && rows() != 1 && cols() != 1) {
+    INFO("\n  There cannot exist closed tours on boards smaller than 3 x 3\n");
+    INFO("  Aborting computation...\n");
+    exit(0);
+  }
 
   // ========================================================================
   // Initialise package manager

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -84,10 +84,6 @@ bool is_reachable(int r, int c)
 template<typename adapter_t>
 typename adapter_t::dd_t knights_tour_rel(adapter_t &adapter, int t);
 
-// TODO: Define 'knights_tour_ham(t)' for regular DFS implementations.
-template<typename adapter_t>
-typename adapter_t::dd_t knights_tour_ham(adapter_t &adapter, int r, int c);
-
 // TODO: Define 'knights_tour_rel_ham(t)' for regular DFS implementations.
 template<typename adapter_t>
 typename adapter_t::dd_t knights_tour_ham_rel(adapter_t &adapter, int t);
@@ -127,6 +123,11 @@ typename adapter_t::dd_t knights_tour_iter_rel(adapter_t &adapter)
 
 // ========================================================================== //
 //                            Add Hamiltonian constraints                     //
+
+// TODO: Define 'knights_tour_ham(t)' for regular DFS implementations.
+template<typename adapter_t>
+typename adapter_t::dd_t knights_tour_ham(adapter_t &adapter, int r, int c);
+
 template<typename adapter_t>
 void knights_tour_iter_ham(adapter_t &adapter, typename adapter_t::dd_t &paths)
 {

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -77,11 +77,9 @@ bool is_legal_position(int r, int c, int t = 0)
 
 bool is_reachable(int r, int c)
 {
-  for (int r_from = 0; r_from < rows(); r_from++) {
-    for (int c_from = 0; c_from < cols(); c_from++) {
-      if (is_legal_move(r_from, c_from, r, c)) {
-        return true;
-      }
+  for (int idx = 0; idx < 8; idx++) {
+    if (is_legal_position(r + row_moves[idx], c + column_moves[idx])) {
+      return true;
     }
   }
   return false;

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -28,6 +28,12 @@ inline int int_of_position(int r, int c, int t = 0)
 inline int MAX_POSITION()
 { return int_of_position(MAX_ROW(), MAX_COL(), MAX_TIME()); }
 
+inline int row_of_position(int pos)
+{ return (pos / cols()) % rows(); }
+
+inline int col_of_position(int pos)
+{ return pos % cols(); }
+
 // ========================================================================== //
 //                          Closed Tour Constraints                           //
 const int closed_squares [3][2] = {{0,0}, {1,2}, {2,1}};
@@ -79,6 +85,22 @@ bool is_reachable(int r, int c)
     }
   }
   return false;
+}
+
+int next_reachable_position(int r, int c, int t)
+{
+  int postulate = int_of_position(r,c,t);
+  bool reachable = false;
+
+  do {
+    postulate++;
+    const int row = row_of_position(postulate);
+    const int col = col_of_position(postulate);
+
+    reachable = is_reachable(row,col);
+  } while (!reachable);
+
+  return postulate;
 }
 
 // TODO: Define 'knights_tour_rel(t)' for regular DFS implementations.

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -149,7 +149,11 @@ void knights_tour_iter_ham(adapter_t &adapter, typename adapter_t::dd_t &paths)
 enum iter_opt { SPLIT_OPEN, SPLIT_CLOSED, COMBINED_OPEN, COMBINED_CLOSED };
 
 template<>
-iter_opt parse_variable_ordering(const std::string &arg, bool &should_exit)
+std::string option_help_str<iter_opt>()
+{ return "Desired Variable ordering"; }
+
+template<>
+iter_opt parse_option(const std::string &arg, bool &should_exit)
 {
   if (arg == "SPLIT_OPEN" || arg == "OPEN" || arg == "SPLIT")
   { return iter_opt::SPLIT_OPEN; }

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -1,0 +1,162 @@
+#include "common.cpp"
+
+size_t largest_bdd = 0;
+size_t total_nodes = 0;
+
+// ========================================================================== //
+//                             Board Indexation                               //
+
+inline int cols()
+{ return N / 2; }
+
+inline int MAX_COL()
+{ return cols() - 1; }
+
+inline int rows()
+{ return N - cols(); }
+
+inline int MAX_ROW()
+{ return rows() - 1; }
+
+inline int MAX_TIME()
+{ return rows() * cols() - 1; }
+
+inline int int_of_position(int r, int c, int t = 0)
+{ return (rows() * cols() * t) + (cols() * r) + c; }
+
+inline int MAX_POSITION()
+{ return int_of_position(MAX_ROW(), MAX_COL(), MAX_TIME()); }
+
+// ========================================================================== //
+//                          Closed Tour Constraints                           //
+const int closed_squares [3][2] = {{0,0}, {1,2}, {2,1}};
+
+bool is_closed_square(int r, int c)
+{
+  return (r == closed_squares[0][0] && c == closed_squares[0][1])
+    || (r == closed_squares[1][0] && c == closed_squares[1][1])
+    || (r == closed_squares[2][0] && c == closed_squares[2][1]);
+}
+
+// TODO: Define 'knights_tour_closed()' for regular DFS implementations.
+template<typename adapter_t>
+typename adapter_t::dd_t knights_tour_closed(adapter_t &adapter);
+
+// ========================================================================== //
+//                 Transition Relation + Hamiltonian Constraint               //
+
+constexpr int row_moves[8]    = { -2, -2, -1, -1,  1,  1,  2,  2 };
+constexpr int column_moves[8] = { -1,  1, -2,  2, -2,  2, -1,  1 };
+
+bool is_legal_move(int r_from, int c_from, int r_to, int c_to)
+{
+  for (int idx = 0; idx < 8; idx++) {
+    if (r_from + row_moves[idx] == r_to &&
+        c_from + column_moves[idx] == c_to) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool is_legal_position(int r, int c, int t = 0)
+{
+  if (r < 0 || MAX_ROW() < r)  { return false; }
+  if (c < 0 || MAX_COL() < c)  { return false; }
+  if (t < 0 || MAX_TIME() < t) { return false; }
+
+  return true;
+}
+
+// TODO: Define 'knights_tour_rel(t)' for regular DFS implementations.
+template<typename adapter_t>
+typename adapter_t::dd_t knights_tour_rel(adapter_t &adapter, int t);
+
+// ========================================================================== //
+//                    Iterate over the above Transition Relation              //
+template<typename adapter_t>
+typename adapter_t::dd_t knights_tour_iter(adapter_t &adapter)
+{
+  typename adapter_t::dd_t res = knights_tour_rel<adapter_t>(adapter, MAX_TIME()-1);
+
+  for (int t = MAX_TIME()-2; t >= 0; t--) {
+    res &= knights_tour_rel<adapter_t>(adapter, t);
+
+    const size_t nodecount = adapter.nodecount(res);
+    largest_bdd = std::max(largest_bdd, nodecount);
+    total_nodes += nodecount;
+  }
+
+  return res;
+}
+
+// ========================================================================== //
+template<typename adapter_t>
+void run_knights_tour(int argc, char** argv)
+{
+  no_variable_order variable_order = no_variable_order::NO_ORDERING;
+  N = 8; // Default N value
+  bool should_exit = parse_input(argc, argv, variable_order);
+  if (should_exit) { exit(-1); }
+
+  if (rows() == 0 || cols() == 0) {
+    ERROR("  Please provide an N > 1 (-N)\n");
+    exit(-1);
+  }
+
+  // =========================================================================
+  INFO("%i x %i - Knight's Tour (%s %i MiB):\n", rows(), cols(), adapter_t::NAME.c_str(), M);
+
+  // ========================================================================
+  // Initialise package manager
+  time_point t_init_before = get_timestamp();
+  adapter_t adapter(MAX_POSITION()+1);
+  time_point t_init_after = get_timestamp();
+  INFO("\n   %s initialisation:\n", adapter_t::NAME.c_str());
+  INFO("   | time (ms):              %zu\n", duration_of(t_init_before, t_init_after));
+
+  uint64_t solutions;
+  {
+    // ========================================================================
+    // Compute the decision diagram that represents all hamiltonian paths
+    time_point t1 = get_timestamp();
+
+    typename adapter_t::dd_t res = rows() == 1 && cols() == 1
+      ? adapter.ithvar(int_of_position(0,0,0))
+      : knights_tour_iter(adapter);
+
+    time_point t2 = get_timestamp();
+
+    const auto construction_time = duration_of(t1,t2);
+
+    INFO("\n   Decision diagram construction:\n");
+    INFO("   | total no. nodes:        %zu\n", total_nodes);
+    INFO("   | largest size (nodes):   %zu\n", largest_bdd);
+    INFO("   | final size (nodes):     %zu\n", adapter.nodecount(res));
+    INFO("   | time (ms):              %zu\n", construction_time);
+
+    // ========================================================================
+    // Count number of solutions
+    time_point t3 = get_timestamp();
+    solutions = adapter.satcount(res);
+    time_point t4 = get_timestamp();
+
+    const auto counting_time = duration_of(t3,t4);
+
+    INFO("\n   Counting solutions:\n");
+    INFO("   | number of solutions:    %zu\n", solutions);
+    INFO("   | time (ms):              %zu\n", counting_time);
+
+    // ========================================================================
+    INFO("\n   total time (ms):          %zu\n", construction_time + counting_time);
+  }
+
+  adapter.print_stats();
+
+  /* TODO
+  if (N < size(expected_queens) && solutions != expected_queens[N]) {
+    EXIT(-1);
+  }
+  */
+  FLUSH();
+}

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -91,7 +91,7 @@ typename adapter_t::dd_t knights_tour_ham_rel(adapter_t &adapter, int t);
 
 // ========================================================================== //
 //                    Iterate over the above Transition Relation              //
-bool closed = true;
+bool closed = false;
 bool ham_rel = false;
 
 template<typename adapter_t>
@@ -101,15 +101,16 @@ typename adapter_t::dd_t knights_tour_iter_rel(adapter_t &adapter)
 
   typename adapter_t::dd_t res;
 
+  int t = MAX_TIME()-1;
   if (closed) {
     res = knights_tour_closed<adapter_t>(adapter);
   } else {
     res = ham_rel
-      ? knights_tour_ham_rel<adapter_t>(adapter, MAX_TIME()-1)
-      : knights_tour_rel<adapter_t>(adapter, MAX_TIME()-1);
+      ? knights_tour_ham_rel<adapter_t>(adapter, t)
+      : knights_tour_rel<adapter_t>(adapter, t);
   }
 
-  for (int t = MAX_TIME()-2; t >= 2*closed; t--) {
+  while (t-- > closed) {
     res &= ham_rel
       ? knights_tour_ham_rel<adapter_t>(adapter, t)
       : knights_tour_rel<adapter_t>(adapter, t);

--- a/src/knights_tour.cpp
+++ b/src/knights_tour.cpp
@@ -160,7 +160,7 @@ iter_opt parse_option(const std::string &arg, bool &should_exit)
   { return iter_opt::SPLIT_OPEN; }
 
   if (arg == "SPLIT_CLOSED" || arg == "CLOSED")
-  { return iter_opt::SPLIT_OPEN; }
+  { return iter_opt::SPLIT_CLOSED; }
 
   if (arg == "COMBINED_OPEN" || arg == "COMBINED")
   { return iter_opt::COMBINED_OPEN; }

--- a/src/picotrav.cpp
+++ b/src/picotrav.cpp
@@ -722,7 +722,11 @@ bool verify_outputs(const net_t& net_0, const bdd_cache<adapter_t>& cache_0,
 
 // ========================================================================== //
 template<>
-variable_order parse_variable_ordering(const std::string &arg, bool &should_exit)
+std::string option_help_str<variable_order>()
+{ return "Desired Variable ordering"; }
+
+template<>
+variable_order parse_option(const std::string &arg, bool &should_exit)
 {
   if (arg == "INPUT") { return variable_order::INPUT; }
   if (arg == "DFS") { return variable_order::DFS; }

--- a/src/queens.cpp
+++ b/src/queens.cpp
@@ -123,7 +123,7 @@ void run_queens(int argc, char** argv)
     typename adapter_t::dd_t res = queens_B(adapter);
     time_point t2 = get_timestamp();
 
-    const auto construction_time = duration_of(t1,t2);
+    const time_duration construction_time = duration_of(t1,t2);
 
     INFO("\n   Decision diagram construction:\n");
     INFO("   | total no. nodes:        %zu\n", total_nodes);
@@ -137,7 +137,7 @@ void run_queens(int argc, char** argv)
     solutions = adapter.satcount(res);
     time_point t4 = get_timestamp();
 
-    const auto counting_time = duration_of(t3,t4);
+    const time_duration counting_time = duration_of(t3,t4);
 
     INFO("\n   Counting solutions:\n");
     INFO("   | number of solutions:    %zu\n", solutions);

--- a/src/queens.cpp
+++ b/src/queens.cpp
@@ -99,9 +99,9 @@ typename adapter_t::dd_t queens_B(adapter_t &adapter)
 template<typename adapter_t>
 void run_queens(int argc, char** argv)
 {
-  no_variable_order variable_order = no_variable_order::NO_ORDERING;
+  no_options option = no_options::NONE;
   N = 8; // Default N value
-  bool should_exit = parse_input(argc, argv, variable_order);
+  bool should_exit = parse_input(argc, argv, option);
   if (should_exit) { exit(-1); }
 
   // =========================================================================

--- a/src/sat_pigeonhole_principle.cpp
+++ b/src/sat_pigeonhole_principle.cpp
@@ -50,9 +50,9 @@ void construct_PHP_cnf(sat_solver<adapter_t> &solver)
 template<typename adapter_t>
 void run_sat_pigeonhole_principle(int argc, char** argv)
 {
-  no_variable_order variable_order = no_variable_order::NO_ORDERING;
+  no_options option = no_options::NONE;
   N = 8;
-  bool should_exit = parse_input(argc, argv, variable_order);
+  bool should_exit = parse_input(argc, argv, option);
   if (should_exit) { exit(-1); }
 
   bool satisfiable = true;

--- a/src/sat_queens.cpp
+++ b/src/sat_queens.cpp
@@ -136,9 +136,9 @@ void construct_Queens_cnf(sat_solver<adapter_t> &solver)
 template<typename adapter_t>
 void run_sat_queens(int argc, char** argv)
 {
-  no_variable_order variable_order = no_variable_order::NO_ORDERING;
+  no_options option = no_options::NONE;
   N = 6;
-  bool should_exit = parse_input(argc, argv, variable_order);
+  bool should_exit = parse_input(argc, argv, option);
   if (should_exit) { exit(-1); }
 
   bool satisfiable = N != 2 && N != 3;
@@ -150,18 +150,18 @@ void run_sat_queens(int argc, char** argv)
 
     uint64_t varcount = label_of_position(N-1, N-1)+1;
 
-    auto t_init_before = get_timestamp();
+    time_point t_init_before = get_timestamp();
     sat_solver<adapter_t> solver(varcount);
-    auto t_init_after = get_timestamp();
+    time_point t_init_after = get_timestamp();
     INFO("\n   %s initialisation:\n", adapter_t::NAME.c_str());
     INFO("   | time (ms):                %zu\n", duration_of(t_init_before, t_init_after));
 
     // =========================================================================
     INFO("\n   CNF construction:\n");
 
-    auto t1 = get_timestamp();
+    time_point t1 = get_timestamp();
     construct_Queens_cnf(solver);
-    auto t2 = get_timestamp();
+    time_point t2 = get_timestamp();
 
     INFO("   | variables:                %zu\n", solver.var_count());
     INFO("   | clauses:                  %zu\n", solver.cnf_size());
@@ -171,9 +171,9 @@ void run_sat_queens(int argc, char** argv)
     INFO("\n   Decision diagram satisfiability solving:\n");
 
 #ifndef GRENDEL
-    auto t3 = get_timestamp();
+    time_point t3 = get_timestamp();
     satisfiable = solver.check_satisfiable();
-    auto t4 = get_timestamp();
+    time_point t4 = get_timestamp();
     INFO("   | solution:                 %s\n", satisfiable ? "SATISFIABLE" : "UNSATISFIABLE");
     INFO("   | operations:\n");
     INFO("   | | exists:                 %zu\n", solver.exists_count());
@@ -187,9 +187,9 @@ void run_sat_queens(int argc, char** argv)
     // =========================================================================
     INFO("\n   Decicsion Diagram counting:\n");
 
-    auto t5 = get_timestamp();
+    time_point t5 = get_timestamp();
     solutions = solver.check_satcount();
-    auto t6 = get_timestamp();
+    time_point t6 = get_timestamp();
     INFO("   | solutions:                %zu\n", solutions);
     INFO("   | operations:\n");
     INFO("   | | apply:                  %zu\n", solver.apply_count());

--- a/src/tic_tac_toe.cpp
+++ b/src/tic_tac_toe.cpp
@@ -137,9 +137,9 @@ typename adapter_t::dd_t construct_is_not_winning(adapter_t &adapter, std::array
 template<typename adapter_t>
 void run_tic_tac_toe(int argc, char** argv)
 {
-  no_variable_order variable_order = no_variable_order::NO_ORDERING;
+  no_options option = no_options::NONE;
   N = 20;
-  bool should_exit = parse_input(argc, argv, variable_order);
+  bool should_exit = parse_input(argc, argv, option);
   if (should_exit) { exit(-1); }
 
   // =========================================================================

--- a/src/tic_tac_toe.cpp
+++ b/src/tic_tac_toe.cpp
@@ -145,9 +145,9 @@ void run_tic_tac_toe(int argc, char** argv)
   // =========================================================================
   INFO("Tic-Tac-Toe with %i crosses (%s %i MiB):\n", N, adapter_t::NAME.c_str(), M);
 
-  auto t_init_before = get_timestamp();
+  time_point t_init_before = get_timestamp();
   adapter_t adapter(64);
-  auto t_init_after = get_timestamp();
+  time_point t_init_after = get_timestamp();
   INFO("\n   %s initialisation:\n", adapter_t::NAME.c_str());
   INFO("   | time (ms):              %zu\n", duration_of(t_init_before, t_init_after));
 
@@ -159,12 +159,12 @@ void run_tic_tac_toe(int argc, char** argv)
     // Construct is_equal_N
     INFO("\n   Initial decision diagram:\n");
 
-    auto t1 = get_timestamp();
+    time_point t1 = get_timestamp();
     typename adapter_t::dd_t res = construct_init(adapter);
     size_t initial_bdd = adapter.nodecount(res);
-    auto t2 = get_timestamp();
+    time_point t2 = get_timestamp();
 
-    const auto init_time = duration_of(t1,t2);
+    const time_duration init_time = duration_of(t1,t2);
 
     INFO("   | size (nodes):           %zu\n", initial_bdd);
     INFO("   | time (ms):              %zu\n", init_time);
@@ -176,7 +176,7 @@ void run_tic_tac_toe(int argc, char** argv)
     size_t largest_bdd = 0;
     size_t total_nodes = initial_bdd;
 
-    auto t3 = get_timestamp();
+    time_point t3 = get_timestamp();
 
     for (auto &line : lines) {
       res &= construct_is_not_winning(adapter, line);
@@ -186,9 +186,9 @@ void run_tic_tac_toe(int argc, char** argv)
       total_nodes += nodecount + 4 /* from construct_is_not_winning */;
     }
 
-    auto t4 = get_timestamp();
+    time_point t4 = get_timestamp();
 
-    const auto constraints_time = duration_of(t3,t4);
+    const time_duration constraints_time = duration_of(t3,t4);
 
     INFO("   | total no. nodes:        %zu\n", total_nodes);
     INFO("   | largest size (nodes):   %zu\n", largest_bdd);
@@ -199,11 +199,11 @@ void run_tic_tac_toe(int argc, char** argv)
     // Count number of solutions
     INFO("\n   counting solutions:\n");
 
-    auto t5 = get_timestamp();
+    time_point t5 = get_timestamp();
     solutions = adapter.satcount(res);
-    auto t6 = get_timestamp();
+    time_point t6 = get_timestamp();
 
-    const auto counting_time = duration_of(t5,t6);
+    const time_duration counting_time = duration_of(t5,t6);
 
     // =========================================================================
     INFO("   | number of solutions:    %zu\n", solutions);


### PR DESCRIPTION
Moves over the Knight's Tour benchmark from the *Adiar Example* (closes #27). Also adds the following improvements.

- Supports non-square boards (closes #29)
- May decrease the number of operations by two by incorporating the hamiltonian constraint into the transition relation (closes #28)
- Applies all transition relations backwards rather than forwards (closes #30)