### PR TITLE
Qbf/Predicate Quantification

### DIFF
--- a/src/adiar/adapter.h
+++ b/src/adiar/adapter.h
@@ -79,13 +79,7 @@ public:
   template<class IT>
   inline adiar::bdd
   exists(const adiar::bdd &b, IT rbegin, IT rend)
-  {
-    adiar::bdd res = b;
-    while (rbegin != rend) {
-      res = exists(res, *(rbegin++));
-    }
-    return res;
-  }
+  { return adiar::bdd_exists(b, rbegin, rend); }
 
   inline adiar::bdd
   forall(const adiar::bdd &b, int label)
@@ -94,13 +88,7 @@ public:
   template<class IT>
   inline adiar::bdd
   forall(const adiar::bdd &b, IT rbegin, IT rend)
-  {
-    adiar::bdd res = b;
-    while (rbegin != rend) {
-      res = forall(res, *(rbegin++));
-    }
-    return res;
-  }
+  { return adiar::bdd_forall(b, rbegin, rend); }
 
   inline uint64_t
   nodecount(const adiar::bdd &b)

--- a/src/adiar/adapter.h
+++ b/src/adiar/adapter.h
@@ -76,6 +76,10 @@ public:
   exists(const adiar::bdd &b, int label)
   { return adiar::bdd_exists(b,label); }
 
+  inline adiar::bdd
+  exists(const adiar::bdd &b, const std::function<bool(int)> &pred)
+  { return adiar::bdd_exists(b, pred); }
+
   template<class IT>
   inline adiar::bdd
   exists(const adiar::bdd &b, IT rbegin, IT rend)
@@ -84,6 +88,10 @@ public:
   inline adiar::bdd
   forall(const adiar::bdd &b, int label)
   { return adiar::bdd_forall(b,label); }
+
+  inline adiar::bdd
+  forall(const adiar::bdd &b, const std::function<bool(int)> &pred)
+  { return adiar::bdd_forall(b, pred); }
 
   template<class IT>
   inline adiar::bdd

--- a/src/buddy/adapter.h
+++ b/src/buddy/adapter.h
@@ -64,11 +64,13 @@ public:
   typedef bdd build_node_t;
 
 private:
+  const int _varcount;
   dd_t _latest_build;
 
   // Init and Deinit
 public:
   buddy_bdd_adapter(int varcount)
+    : _varcount(varcount)
   {
 #ifndef BDD_BENCHMARK_GRENDEL
     const buddy_init_size init_size = compute_init_size();
@@ -116,6 +118,17 @@ private:
     return res;
   }
 
+  inline bdd make_cube(const std::function<bool(int)> &pred)
+  {
+    bdd res = top();
+    for (int i = _varcount-1; 0 <= i; --i) {
+      if (pred(i)) {
+        res = bdd_ite(bdd_ithvar(i), res, bot());
+      }
+    }
+    return res;
+  }
+
   // BDD Operations
 public:
   inline bdd top()
@@ -139,12 +152,18 @@ public:
   inline bdd exists(const bdd &b, int label)
   { return bdd_exist(b, bdd_ithvar(label)); }
 
+  inline bdd exists(const bdd &b, const std::function<bool(int)> &pred)
+  { return bdd_exist(b, make_cube(pred)); }
+
   template<typename IT>
   inline bdd exists(const bdd &b, IT rbegin, IT rend)
   { return bdd_exist(b, make_cube(rbegin, rend)); }
 
   inline bdd forall(const bdd &b, int label)
   { return bdd_forall(b, bdd_ithvar(label)); }
+
+  inline bdd forall(const bdd &b, const std::function<bool(int)> &pred)
+  { return bdd_forall(b, make_cube(pred)); }
 
   template<typename IT>
   inline bdd forall(const bdd &b, IT rbegin, IT rend)

--- a/src/cal/adapter.h
+++ b/src/cal/adapter.h
@@ -58,6 +58,15 @@ public:
     return exists(b, i.begin(), i.end());
   }
 
+  inline BDD exists(const BDD &b, const std::function<bool(int)> &pred)
+  {
+    const int assoc = convert_to_association_list(pred);
+    _mgr.AssociationSetCurrent(assoc);
+    const BDD res = _mgr.Exists(b);
+    _mgr.AssociationQuit(assoc);
+    return res;
+  }
+
   template<typename IT>
   inline BDD exists(const BDD &b, IT rbegin, IT rend)
   {
@@ -73,6 +82,15 @@ public:
     std::vector<int> i;
     i.push_back(label);
     return forall(b, i.begin(), i.end());
+  }
+
+  inline BDD forall(const BDD &b, const std::function<bool(int)> &pred)
+  {
+    const int assoc = convert_to_association_list(pred);
+    _mgr.AssociationSetCurrent(assoc);
+    const BDD res = _mgr.ForAll(b);
+    _mgr.AssociationQuit(assoc);
+    return res;
   }
 
   template<typename IT>
@@ -128,6 +146,19 @@ private:
 
     while (begin != end) {
       vec.push_back(ithvar(*(begin++)));
+    }
+
+    return _mgr.AssociationInit(vec.begin(), vec.end());
+  }
+
+  int convert_to_association_list(const std::function<bool(int)> &pred)
+  {
+    std::vector<BDD> vec;
+
+    for (int i = 0; i < _varcount; ++i) {
+      if (pred(i)) {
+        vec.push_back(ithvar(i));
+      }
     }
 
     return _mgr.AssociationInit(vec.begin(), vec.end());

--- a/src/cal/adapter.h
+++ b/src/cal/adapter.h
@@ -80,7 +80,7 @@ public:
   {
     const int assoc = convert_to_association_list(rbegin, rend);
     _mgr.AssociationSetCurrent(assoc);
-    const BDD res = _mgr.Exists(b);
+    const BDD res = _mgr.ForAll(b);
     _mgr.AssociationQuit(assoc);
     return res;
   }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <assert.h>
 #include <ostream>
+#include <functional>
 
 // =============================================================================
 // Global constants

--- a/src/cudd/adapter.h
+++ b/src/cudd/adapter.h
@@ -114,6 +114,17 @@ private:
     return res;
   }
 
+  inline BDD make_cube(const std::function<bool(int)> &pred)
+  {
+    BDD res = top();
+    for (int i = _varcount-1; 0 <= i; --i) {
+      if (pred(i)) {
+        res = _mgr.bddVar(i).Ite(res, bot());
+      }
+    }
+    return res;
+  }
+
   // BDD Operations
 public:
   inline BDD top()
@@ -137,12 +148,18 @@ public:
   inline BDD exists(const BDD &b, int label)
   { return b.ExistAbstract(_mgr.bddVar(label)); }
 
+  inline BDD exists(const BDD &b, const std::function<bool(int)> &pred)
+  { return b.ExistAbstract(make_cube(pred)); }
+
   template<typename IT>
   inline BDD exists(const BDD &b, IT rbegin, IT rend)
   { return b.ExistAbstract(make_cube(rbegin, rend)); }
 
   inline BDD forall(const BDD &b, int label)
   { return b.UnivAbstract(_mgr.bddVar(label)); }
+
+  inline BDD forall(const BDD &b, const std::function<bool(int)> &pred)
+  { return b.UnivAbstract(make_cube(pred)); }
 
   template<typename IT>
   inline BDD forall(const BDD &b, IT rbegin, IT rend)

--- a/src/qbf.cpp
+++ b/src/qbf.cpp
@@ -1862,9 +1862,19 @@ solve(adapter_t& adapter, qcir& q,
          std::cout << "]\n";
 #endif
 
+         // iterator quantification
+         /*
          return g.quant == qcir::quant_gate::EXISTS
            ? adapter.exists(cache_get(g.lit), vars.crbegin(), vars.crend())
            : adapter.forall(cache_get(g.lit), vars.crbegin(), vars.crend());
+         */
+
+         // predicated quantification
+         const auto pred = [&vars](int i) { return vars.find(i) != vars.end(); };
+
+         return g.quant == qcir::quant_gate::EXISTS
+           ? adapter.exists(cache_get(g.lit), pred)
+           : adapter.forall(cache_get(g.lit), pred);
        },
        [&cache_get, &t_prenex_before]
        (const qcir::output_gate &g) -> typename adapter_t::dd_t {

--- a/src/sylvan/adapter.h
+++ b/src/sylvan/adapter.h
@@ -84,6 +84,17 @@ private:
     return res;
   }
 
+  inline sylvan::Bdd make_cube(const std::function<bool(int)> &pred)
+  {
+    sylvan::Bdd res = top();
+    for (int i = _varcount-1; 0 <= i; --i) {
+      if (pred(i)) {
+        res = sylvan::Bdd::bddVar(i).Ite(res, bot());
+      }
+    }
+    return res;
+  }
+
   // BDD Operations
 public:
   inline sylvan::Bdd top()
@@ -109,12 +120,18 @@ public:
   inline sylvan::Bdd exists(const sylvan::Bdd &b, int label)
   { return b.ExistAbstract(sylvan::Bdd::bddVar(label)); }
 
+  inline sylvan::Bdd exists(const sylvan::Bdd &b, const std::function<bool(int)> &pred)
+  { return b.ExistAbstract(make_cube(pred)); }
+
   template<typename IT>
   inline sylvan::Bdd exists(const sylvan::Bdd &b, IT rbegin, IT rend)
   { return b.ExistAbstract(make_cube(rbegin, rend)); }
 
   inline sylvan::Bdd forall(const sylvan::Bdd &b, int label)
   { return b.UnivAbstract(sylvan::Bdd::bddVar(label)); }
+
+  inline sylvan::Bdd forall(const sylvan::Bdd &b, const std::function<bool(int)> &pred)
+  { return b.UnivAbstract(make_cube(pred)); }
 
   template<typename IT>
   inline sylvan::Bdd forall(const sylvan::Bdd &b, IT rbegin, IT rend)

--- a/src/sylvan/adapter.h
+++ b/src/sylvan/adapter.h
@@ -43,12 +43,13 @@ public:
   typedef sylvan::Bdd build_node_t;
 
 private:
-  int varcount;
+  const int _varcount;
   sylvan::Bdd _latest_build;
 
   // Init and Deinit
 public:
-  sylvan_bdd_adapter(int varcount) : varcount(varcount)
+  sylvan_bdd_adapter(int varcount)
+    : _varcount(varcount)
   {
     // Init LACE
     lace_start(1, 1000000);
@@ -123,7 +124,7 @@ public:
   { return b.NodeCount() - 1; }
 
   inline uint64_t satcount(const sylvan::Bdd &b)
-  { return b.SatCount(varcount); }
+  { return b.SatCount(_varcount); }
 
   inline std::vector<std::pair<int, char>>
   pickcube(const sylvan::Bdd &b)


### PR DESCRIPTION
Since Adiar allows for *repeated partial quantification*, the QBF benchmark is changed to not use an iterator, but instead provide a predicate.

Furthermore:

- Make the Adiar adapter use the v2.0 interface.
- Forward to Adiar v2.0-beta.4.4 (partial quantification)
- Fix CAL adapter by accident calls *exists* rather than *forall*.