### PR TITLE
Use Grendel flag for Sylvan Initialisation

### DIFF
--- a/src/sylvan/adapter.h
+++ b/src/sylvan/adapter.h
@@ -61,9 +61,18 @@ public:
     const size_t memory_bytes = static_cast<size_t>(M) * 1024u * 1024u;
 
     // Init Sylvan
-    sylvan::sylvan_set_limits(memory_bytes,      // Set memory limit
-                              log2(CACHE_RATIO), // Set (exponent) of cache ratio
-                              0);                // Initialise unique node table to full size
+    sylvan::sylvan_set_limits(// Set memory limit
+                              memory_bytes,
+                              // Set (exponent) of cache ratio
+                              log2(CACHE_RATIO),
+#ifndef BDD_BENCHMARK_GRENDEL
+                              // Initialise unique node table to full size
+                              0
+#else
+                              // On Grendel, initialize unique node table to 1/2^12th (~75 MiB)
+                              12
+#endif
+                              );
     sylvan::sylvan_set_granularity(1);
     sylvan::sylvan_init_package();
     sylvan::sylvan_init_bdd();


### PR DESCRIPTION
On Grendel, we want it to run with a factor 12 rather than 0. This way, I am not going to forget manually setting the value in one of the clones of this repository