### PR TITLE
Simplify derivation of 'mirror_diagonal' variable ordering

### DIFF
--- a/src/game-of-life.cpp
+++ b/src/game-of-life.cpp
@@ -415,13 +415,10 @@ public:
         const int max_col = MAX_COL(prime::pre) - (MAX_ROW(prime::pre) - row);
 
         for (int col = MIN_COL(prime::pre); col <= max_col; ++col) {
-          const int mirror_row  = col;
-          const int mirror_col  = row;
-
-          const bool add_mirror = mirror_row < row;
+          const bool add_mirror = col < row;
 
           // pre variable(s)
-          const cell pre_mirror(mirror_row, mirror_col, prime::pre);
+          const cell pre_mirror(col, row, prime::pre);
           assert(!pre_mirror.out_of_range());
 
           if (add_mirror) {


### PR DESCRIPTION
Reinvestegates the code from CMU. This only ended up as a clean-up, not an actual change in features (I have written down some notes in #92  instead). For now, since the accumulation of the transition relation takes very little time, I have just split the final quantification step in two: the "easy" part (the ones symmetric to the ones quantified during its construction) and the "hard" part (anything else). This requires an inversion of the symmetry, which is not fully done (see #93).