### PR TITLE
Integrate Biodivine/LibBDD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "external/cal"]
 	path = external/cal
 	url = ../../SSoelvsten/cal
+[submodule "external/lib-bdd-ffi"]
+	path = external/lib-bdd-ffi
+	url = ../../nhusung/lib-bdd-ffi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ set_target_properties(cudd PROPERTIES
   IMPORTED_LOCATION ${CUDD_INSTALL_DIR}/lib/libcudd.a
   INTERFACE_INCLUDE_DIRECTORIES ${CUDD_INSTALL_DIR}/include)
 
+# Biodivine/LibBDD (Samuel Pastva et al. - Institute of Science and Technology Austria)
+add_subdirectory(external/lib-bdd-ffi lib-bdd-ffi EXCLUDE_FROM_ALL)
+
 # Sylvan Package (Tom van Dijk - University of Twente, Netherlands)
 if (BDD_BENCHMARK_STATS)
   set(SYLVAN_STATS ON)

--- a/makefile
+++ b/makefile
@@ -28,7 +28,7 @@ build:
 
   # Build all bdd benchmarks
 	@echo -e "\n\nBuild BDD Benchmarks"
-	@cd build/ && for package in 'adiar' 'buddy' 'cal' 'cudd' 'sylvan' ; do \
+	@cd build/ && for package in 'adiar' 'buddy' 'cal' 'cudd' 'libbdd' 'sylvan' ; do \
 		mkdir -p ../out/$$package ; \
 		mkdir -p ../out/$$package/bdd ; \
 		for benchmark in 'apply' 'game-of-life' 'hamiltonian' 'picotrav' 'qbf' 'queens' 'tic-tac-toe' ; do \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,17 @@ macro(add_bdd_benchmark NAME)
     target_compile_definitions(cudd_${NAME}_bdd PRIVATE BDD_BENCHMARK_WAIT)
   endif()
 
+  # Biodivine/LibBDD
+  add_executable(libbdd_${NAME}_bdd libbdd/${NAME}_bdd.cpp)
+  target_link_libraries(libbdd_${NAME}_bdd PRIVATE lib-bdd-ffi)
+  target_link_libraries(libbdd_${NAME}_bdd PRIVATE common)
+  if (BDD_BENCHMARK_GRENDEL)
+    target_compile_definitions(libbdd_${NAME}_bdd PRIVATE BDD_BENCHMARK_GRENDEL)
+  endif()
+  if (BDD_BENCHMARK_STATS)
+    target_compile_definitions(libbdd_${NAME}_bdd PRIVATE BDD_BENCHMARK_STATS)
+  endif()
+
   # Sylvan
   add_executable(sylvan_${NAME}_bdd sylvan/${NAME}_bdd.cpp)
   target_link_libraries(sylvan_${NAME}_bdd PRIVATE Sylvan::Sylvan)
@@ -113,6 +124,7 @@ macro(link_bdd_extra NAME LIB_NAME)
   target_link_libraries(buddy_${NAME}_bdd  PRIVATE ${LIB_NAME})
   target_link_libraries(cal_${NAME}_bdd    PRIVATE ${LIB_NAME})
   target_link_libraries(cudd_${NAME}_bdd   PRIVATE ${LIB_NAME})
+  target_link_libraries(libbdd_${NAME}_bdd PRIVATE ${LIB_NAME})
   target_link_libraries(sylvan_${NAME}_bdd PRIVATE ${LIB_NAME})
 endmacro(link_bdd_extra)
 

--- a/src/adiar/adapter.h
+++ b/src/adiar/adapter.h
@@ -1,9 +1,9 @@
-#include <assert.h>
+#include <cassert>
 #include <cstdlib>
 #include <string>
 #include <string_view>
 
-#include "../common/input.h"
+#include "../common/adapter.h"
 
 #include <adiar/adiar.h>
 

--- a/src/apply.cpp
+++ b/src/apply.cpp
@@ -2,10 +2,7 @@
 #include <algorithm>
 
 // Assertions
-#include <assert.h>
-
-// Assertions
-#include <assert.h>
+#include <cassert>
 
 // Data Structures
 #include <array>
@@ -20,7 +17,7 @@
 #include <fstream>
 
 // Types
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <limits>
 

--- a/src/buddy/adapter.h
+++ b/src/buddy/adapter.h
@@ -1,4 +1,4 @@
-#include <assert.h>
+#include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -7,7 +7,7 @@
 #include <string>
 #include <string_view>
 
-#include "../common/input.h"
+#include "../common/adapter.h"
 
 #include <bdd.h>
 

--- a/src/cal/adapter.h
+++ b/src/cal/adapter.h
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>

--- a/src/cudd/adapter.h
+++ b/src/cudd/adapter.h
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
@@ -8,7 +7,7 @@
 #include <string>
 #include <string_view>
 
-#include "../common/input.h"
+#include "../common/adapter.h"
 
 #include "cudd.h"
 #include "cuddObj.hh"

--- a/src/game-of-life.cpp
+++ b/src/game-of-life.cpp
@@ -1,5 +1,5 @@
 // Assertions
-#include <assert.h>
+#include <cassert>
 
 // Data Structures
 #include <set>

--- a/src/hamiltonian.cpp
+++ b/src/hamiltonian.cpp
@@ -1,5 +1,5 @@
 // Assertions
-#include <assert.h>
+#include <cassert>
 
 // Data Structures
 #include <array>

--- a/src/libbdd/adapter.h
+++ b/src/libbdd/adapter.h
@@ -1,0 +1,607 @@
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "../common/adapter.h"
+
+#include "lib-bdd.h"
+
+namespace lib_bdd
+{
+
+  class bdd_function;
+
+  enum class opt_bool : int8_t
+  {
+    NONE  = -1,
+    FALSE = 0,
+    TRUE  = 1,
+  };
+
+  class assignment
+  {
+    const capi::bdd_assignment_t _assignment;
+
+    assignment(capi::bdd_assignment_t a)
+      : _assignment(a)
+    {}
+
+    assignment(assignment& other) = delete; // use as_vector() to copy
+    friend class bdd_function;
+
+  public:
+    ~assignment()
+    {
+      bdd_assignment_free(_assignment);
+    }
+
+    const opt_bool*
+    data() const
+    {
+      return (opt_bool*)_assignment.data;
+    }
+
+    size_t
+    size() const
+    {
+      return _assignment.len;
+    }
+
+    const opt_bool*
+    begin() const
+    {
+      return data();
+    }
+
+    const opt_bool*
+    end() const
+    {
+      return data() + size();
+    }
+
+    const opt_bool*
+    cbegin() const
+    {
+      return data();
+    }
+
+    const opt_bool*
+    cend() const
+    {
+      return data() + size();
+    }
+
+    const opt_bool&
+    operator[](size_t idx)
+    {
+      assert(idx < size());
+      return data()[idx];
+    }
+
+    std::vector<opt_bool>
+    as_vector() const
+    {
+      return std::vector<opt_bool>(begin(), end());
+    }
+  };
+
+  class manager
+  {
+    capi::manager_t _manager;
+
+    manager(capi::manager_t manager)
+      : _manager(manager)
+    {}
+
+  public:
+    manager() noexcept
+    {
+      _manager._p = nullptr;
+    }
+
+    manager(uint16_t num_vars, size_t max_nodes_total) noexcept
+      : _manager(capi::manager_new(num_vars, max_nodes_total))
+    {}
+
+    manager(const manager& other) noexcept
+      : _manager(other._manager)
+    {
+      capi::manager_ref(_manager);
+    }
+
+    manager(manager&& other) noexcept
+      : _manager(other._manager)
+    {
+      other._manager._p = nullptr;
+    }
+
+    ~manager() noexcept
+    {
+      if (_manager._p != nullptr) capi::manager_unref(_manager);
+    }
+
+    bool
+    is_invalid() noexcept
+    {
+      return !_manager._p;
+    }
+
+    size_t
+    node_count() const noexcept
+    {
+      return capi::manager_node_count(_manager);
+    }
+
+    bdd_function
+    ithvar(uint16_t var) const noexcept;
+    bdd_function
+    nithvar(uint16_t var) const noexcept;
+
+    bdd_function
+    top() const noexcept;
+    bdd_function
+    bot() const noexcept;
+  };
+
+  class bdd_function
+  {
+    capi::bdd_t _func;
+
+    friend class manager;
+
+    bdd_function(capi::bdd_t func) noexcept
+      : _func(func)
+    {}
+
+  public:
+    bdd_function() noexcept
+      : _func({ ._p = nullptr })
+    {}
+
+    bdd_function(const bdd_function& other) noexcept
+      : _func(other._func)
+    {
+      capi::bdd_ref(_func);
+    }
+
+    bdd_function(bdd_function&& other) noexcept
+      : _func(other._func)
+    {
+      other._func._p = nullptr;
+    }
+
+    ~bdd_function() noexcept
+    {
+      if (_func._p != nullptr) capi::bdd_unref(_func);
+    }
+
+    bdd_function&
+    operator=(const bdd_function& rhs) noexcept
+    {
+      if (_func._p != nullptr) capi::bdd_unref(_func);
+      _func = rhs._func;
+      if (_func._p != nullptr) capi::bdd_ref(_func);
+      return *this;
+    }
+
+    bdd_function&
+    operator=(bdd_function&& rhs) noexcept
+    {
+      if (_func._p != nullptr) capi::bdd_unref(_func);
+      _func        = rhs._func;
+      rhs._func._p = nullptr;
+      return *this;
+    }
+
+    bool
+    is_invalid() const noexcept
+    {
+      return _func._p == nullptr;
+    }
+
+    bool
+    operator==(const bdd_function& rhs) const noexcept
+    {
+      return (_func._p && rhs._func._p && capi::bdd_eq(_func, rhs._func))
+        || (!_func._p && !rhs._func._p);
+    }
+
+    bool
+    operator!=(const bdd_function& rhs) const noexcept
+    {
+      return !(*this == rhs);
+    }
+
+    bdd_function
+    operator~() const noexcept
+    {
+      return capi::bdd_not(_func);
+    }
+
+    bdd_function
+    operator&(const bdd_function& rhs) const noexcept
+    {
+      assert(_func._p && rhs._func._p);
+      return capi::bdd_and(_func, rhs._func);
+    }
+
+    bdd_function&
+    operator&=(const bdd_function& rhs) noexcept
+    {
+      return (*this = *this & rhs);
+    }
+
+    bdd_function
+    operator|(const bdd_function& rhs) const noexcept
+    {
+      assert(_func._p && rhs._func._p);
+      return capi::bdd_or(_func, rhs._func);
+    }
+
+    bdd_function&
+    operator|=(const bdd_function& rhs) noexcept
+    {
+      return (*this = *this | rhs);
+    }
+
+    bdd_function
+    operator^(const bdd_function& rhs) const noexcept
+    {
+      assert(_func._p && rhs._func._p);
+      return capi::bdd_xor(_func, rhs._func);
+    }
+
+    bdd_function&
+    operator^=(const bdd_function& rhs) noexcept
+    {
+      return (*this = *this | rhs);
+    }
+
+    bdd_function
+    imp(const bdd_function& rhs) const noexcept
+    {
+      assert(_func._p && rhs._func._p);
+      return capi::bdd_imp(_func, rhs._func);
+    }
+
+    bdd_function
+    iff(const bdd_function& rhs) const noexcept
+    {
+      assert(_func._p && rhs._func._p);
+      return capi::bdd_iff(_func, rhs._func);
+    }
+
+    bdd_function
+    and_not(const bdd_function& rhs) const noexcept
+    {
+      assert(_func._p && rhs._func._p);
+      return capi::bdd_and_not(_func, rhs._func);
+    }
+
+    bdd_function
+    ite(const bdd_function& t, const bdd_function& e) const noexcept
+    {
+      assert(_func._p && t._func._p && e._func._p);
+      return capi::bdd_ite(_func, t._func, e._func);
+    }
+
+    bdd_function
+    var_forall(uint16_t var) const noexcept
+    {
+      assert(_func._p);
+      return capi::bdd_var_forall(_func, var);
+    }
+
+    bdd_function
+    var_exists(uint16_t var) const noexcept
+    {
+      assert(_func._p);
+      return capi::bdd_var_exists(_func, var);
+    }
+
+    bdd_function
+    forall(const uint16_t* vars, size_t num_vars) const noexcept
+    {
+      assert(_func._p);
+      return capi::bdd_forall(_func, vars, num_vars);
+    }
+
+    bdd_function
+    exists(const uint16_t* vars, size_t num_vars) const noexcept
+    {
+      assert(_func._p);
+      return capi::bdd_exists(_func, vars, num_vars);
+    }
+
+    uint64_t
+    node_count() const noexcept
+    {
+      assert(_func._p);
+      return capi::bdd_nodecount(_func);
+    }
+
+    double
+    sat_count() const noexcept
+    {
+      assert(_func._p);
+      return capi::bdd_satcount(_func);
+    }
+
+    assignment
+    pickcube() const noexcept
+    {
+      assert(_func._p);
+      return capi::bdd_pickcube(_func);
+    }
+  };
+
+  inline bdd_function
+  manager::ithvar(uint16_t var) const noexcept
+  {
+    assert(_manager._p);
+    return capi::manager_ithvar(_manager, var);
+  }
+
+  inline bdd_function
+  manager::nithvar(uint16_t var) const noexcept
+  {
+    assert(_manager._p);
+    return capi::manager_nithvar(_manager, var);
+  }
+
+  inline bdd_function
+  manager::top() const noexcept
+  {
+    assert(_manager._p);
+    return capi::manager_true(_manager);
+  }
+
+  inline bdd_function
+  manager::bot() const noexcept
+  {
+    assert(_manager._p);
+    return capi::manager_false(_manager);
+  }
+} // namespace lib_bdd
+
+class libbdd_bdd_adapter
+{
+public:
+  static constexpr std::string_view NAME = "LibBDD [BDD]";
+
+  static constexpr bool needs_extend = false;
+
+  using dd_t         = lib_bdd::bdd_function;
+  using build_node_t = lib_bdd::bdd_function;
+
+private:
+  const int _varcount;
+  lib_bdd::manager _manager;
+  lib_bdd::bdd_function _latest_build;
+
+  // Init and Deinit
+public:
+  libbdd_bdd_adapter(int varcount)
+    : _varcount(varcount)
+    , _manager(lib_bdd::manager(varcount, static_cast<size_t>(M) * 1024 * 1024 / 16))
+  {}
+
+  template <typename F>
+  int
+  run(const F& f)
+  {
+    return f();
+  }
+
+  // BDD Operations
+  inline lib_bdd::bdd_function
+  top()
+  {
+    return _manager.top();
+  }
+
+  inline lib_bdd::bdd_function
+  bot()
+  {
+    return _manager.bot();
+  }
+
+  inline lib_bdd::bdd_function
+  ithvar(uint32_t label)
+  {
+    return _manager.ithvar(label);
+  }
+
+  inline lib_bdd::bdd_function
+  nithvar(uint32_t label)
+  {
+    return _manager.nithvar(label);
+  }
+
+  inline lib_bdd::bdd_function
+  apply_and(const lib_bdd::bdd_function& f, const lib_bdd::bdd_function& g)
+  {
+    return f & g;
+  }
+
+  inline lib_bdd::bdd_function
+  apply_or(const lib_bdd::bdd_function& f, const lib_bdd::bdd_function& g)
+  {
+    return f | g;
+  }
+
+  inline lib_bdd::bdd_function
+  apply_diff(const lib_bdd::bdd_function& f, const lib_bdd::bdd_function& g)
+  {
+    return f.and_not(g);
+  }
+
+  inline lib_bdd::bdd_function
+  apply_imp(const lib_bdd::bdd_function& f, const lib_bdd::bdd_function& g)
+  {
+    return f.imp(g);
+  }
+
+  inline lib_bdd::bdd_function
+  apply_xor(const lib_bdd::bdd_function& f, const lib_bdd::bdd_function& g)
+  {
+    return f ^ g;
+  }
+
+  inline lib_bdd::bdd_function
+  apply_xnor(const lib_bdd::bdd_function& f, const lib_bdd::bdd_function& g)
+  {
+    return f.iff(g);
+  }
+
+  inline lib_bdd::bdd_function
+  ite(const lib_bdd::bdd_function& i,
+      const lib_bdd::bdd_function& t,
+      const lib_bdd::bdd_function& e)
+  {
+    return i.ite(t, e);
+  }
+
+  template <typename IT>
+  inline lib_bdd::bdd_function
+  extend(const lib_bdd::bdd_function& f, IT /*begin*/, IT /*end*/)
+  {
+    return f;
+  }
+
+  inline lib_bdd::bdd_function
+  exists(const lib_bdd::bdd_function& b, int label)
+  {
+    return b.var_exists(label);
+  }
+
+  inline lib_bdd::bdd_function
+  exists(const lib_bdd::bdd_function& b, const std::function<bool(int)>& pred)
+  {
+    std::vector<uint16_t> vars;
+    vars.reserve(_varcount);
+    for (uint16_t i = 0; i < _varcount; ++i) {
+      if (pred(i)) vars.push_back(i);
+    }
+    return b.exists(vars.data(), vars.size());
+  }
+
+  template <typename IT>
+  inline lib_bdd::bdd_function
+  exists(const lib_bdd::bdd_function& b, IT rbegin, IT rend)
+  {
+    std::vector<uint16_t> vars(rbegin, rend);
+    return b.exists(vars.data(), vars.size());
+  }
+
+  inline lib_bdd::bdd_function
+  forall(const lib_bdd::bdd_function& b, int label)
+  {
+    return b.var_forall(label);
+  }
+
+  inline lib_bdd::bdd_function
+  forall(const lib_bdd::bdd_function& b, const std::function<bool(int)>& pred)
+  {
+    std::vector<uint16_t> vars;
+    vars.reserve(_varcount);
+    for (uint16_t i = 0; i < _varcount; ++i) {
+      if (pred(i)) vars.push_back(i);
+    }
+    return b.forall(vars.data(), vars.size());
+  }
+
+  template <typename IT>
+  inline lib_bdd::bdd_function
+  forall(const lib_bdd::bdd_function& b, IT rbegin, IT rend)
+  {
+    std::vector<uint16_t> vars(rbegin, rend);
+    return b.forall(vars.data(), vars.size());
+  }
+
+  inline uint64_t
+  nodecount(const lib_bdd::bdd_function& f)
+  {
+    return f.node_count();
+  }
+
+  inline uint64_t
+  satcount(const lib_bdd::bdd_function& f)
+  {
+    return f.sat_count();
+  }
+
+  inline uint64_t
+  satcount(const lib_bdd::bdd_function& f, const size_t vc)
+  {
+    assert(vc <= this->_varcount);
+
+    const double excess_variables = static_cast<double>(this->_varcount) - static_cast<double>(vc);
+
+    return f.sat_count() / std::pow(2, excess_variables);
+  }
+
+  inline std::vector<std::pair<uint32_t, char>>
+  pickcube(const lib_bdd::bdd_function& f)
+  {
+    lib_bdd::assignment sat = f.pickcube();
+
+    std::vector<std::pair<uint32_t, char>> res;
+    res.reserve(sat.size());
+    for (uint32_t x = 0; x < sat.size(); ++x) {
+      const lib_bdd::opt_bool val = sat[x];
+      if (val == lib_bdd::opt_bool::NONE) continue;
+
+      res.emplace_back(x, '0' + static_cast<char>(val));
+    }
+
+    return res;
+  }
+
+  void
+  print_dot(const lib_bdd::bdd_function&, const std::string&)
+  {
+    std::cerr << "libbdd_bdd_adapter does not support dot export" << std::endl;
+  }
+
+  // BDD Build Operations
+public:
+  inline lib_bdd::bdd_function
+  build_node(const bool value)
+  {
+    const lib_bdd::bdd_function res = value ? top() : bot();
+    if (_latest_build.is_invalid()) { _latest_build = res; }
+    return res;
+  }
+
+  inline lib_bdd::bdd_function
+  build_node(const uint32_t label,
+             const lib_bdd::bdd_function& low,
+             const lib_bdd::bdd_function& high)
+  {
+    return _latest_build = ite(ithvar(label), high, low);
+  }
+
+  inline lib_bdd::bdd_function
+  build()
+  {
+    return std::move(_latest_build);
+  }
+
+  // Statistics
+public:
+  inline size_t
+  allocated_nodes()
+  {
+    return _manager.node_count();
+  }
+
+  void
+  print_stats()
+  {}
+};

--- a/src/libbdd/apply_bdd.cpp
+++ b/src/libbdd/apply_bdd.cpp
@@ -1,0 +1,9 @@
+#include "../apply.cpp"
+
+#include "adapter.h"
+
+int
+main(int argc, char** argv)
+{
+  return run_apply<libbdd_bdd_adapter>(argc, argv);
+}

--- a/src/libbdd/game-of-life_bdd.cpp
+++ b/src/libbdd/game-of-life_bdd.cpp
@@ -1,0 +1,9 @@
+#include "../game-of-life.cpp"
+
+#include "adapter.h"
+
+int
+main(int argc, char** argv)
+{
+  return run_gameoflife<libbdd_bdd_adapter>(argc, argv);
+}

--- a/src/libbdd/hamiltonian_bdd.cpp
+++ b/src/libbdd/hamiltonian_bdd.cpp
@@ -1,0 +1,9 @@
+#include "../hamiltonian.cpp"
+
+#include "adapter.h"
+
+int
+main(int argc, char** argv)
+{
+  return run_hamiltonian<libbdd_bdd_adapter>(argc, argv);
+}

--- a/src/libbdd/picotrav_bdd.cpp
+++ b/src/libbdd/picotrav_bdd.cpp
@@ -1,0 +1,9 @@
+#include "../picotrav.cpp"
+
+#include "adapter.h"
+
+int
+main(int argc, char** argv)
+{
+  return run_picotrav<libbdd_bdd_adapter>(argc, argv);
+}

--- a/src/libbdd/qbf_bdd.cpp
+++ b/src/libbdd/qbf_bdd.cpp
@@ -1,0 +1,8 @@
+#include "../qbf.cpp"
+
+#include "adapter.h"
+
+int main(int argc, char **argv) {
+  // TODO: implement pick_cube
+  // run_qbf<lib_bdd_adapter>(argc, argv);
+}

--- a/src/libbdd/queens_bdd.cpp
+++ b/src/libbdd/queens_bdd.cpp
@@ -1,0 +1,9 @@
+#include "../queens.cpp"
+
+#include "adapter.h"
+
+int
+main(int argc, char** argv)
+{
+  return run_queens<libbdd_bdd_adapter>(argc, argv);
+}

--- a/src/libbdd/tic-tac-toe_bdd.cpp
+++ b/src/libbdd/tic-tac-toe_bdd.cpp
@@ -1,0 +1,9 @@
+#include "../tic-tac-toe.cpp"
+
+#include "adapter.h"
+
+int
+main(int argc, char** argv)
+{
+  return run_tictactoe<libbdd_bdd_adapter>(argc, argv);
+}

--- a/src/picotrav.cpp
+++ b/src/picotrav.cpp
@@ -1,5 +1,5 @@
 // Assertions
-#include <assert.h>
+#include <cassert>
 
 // Data Structures
 #include <unordered_map>

--- a/src/qbf.cpp
+++ b/src/qbf.cpp
@@ -4,7 +4,7 @@
 #include <regex>
 
 // Assertions
-#include <assert.h>
+#include <cassert>
 
 // Data Structures
 #include <array>

--- a/src/queens.cpp
+++ b/src/queens.cpp
@@ -1,5 +1,5 @@
 // Assertions
-#include <assert.h>
+#include <cassert>
 
 // Data Structures
 #include <sstream>

--- a/src/sylvan/adapter.h
+++ b/src/sylvan/adapter.h
@@ -1,11 +1,10 @@
-#include <assert.h>
 #include <cstdlib>
 #include <functional>
 #include <iostream>
 #include <string>
 #include <string_view>
 
-#include "../common/input.h"
+#include "../common/adapter.h"
 
 #include <sylvan.h>
 #include <sylvan_table.h>

--- a/src/tic-tac-toe.cpp
+++ b/src/tic-tac-toe.cpp
@@ -1,5 +1,5 @@
 // Assertions
-#include <assert.h>
+#include <cassert>
 
 // Data Structures
 #include <array>


### PR DESCRIPTION
This PR integrates the [Biodivine/LibBDD](https://crates.io/crates/biodivine-lib-bdd) library into BDD benchmark. Biodivine/LibBDD itself is written in Rust and does not come with a C FFI, hence I hacked a [FFI on my own](https://github.com/nhusung/lib-bdd-ffi).

Some remarks:

- I tested most of the benchmarks and they seem to work.
- `lib-bdd-ffi` uses `FetchContent` in CMake and builds a library using `cargo`. Therefore, an internet connection is needed for the first time invoking `cmake` and `make`.
- I did not monitor memory usage yet to see if the maximum node count is set in a meaningful way. AFAIK, LibBDD also does not provide any way to set the maximum apply cache size. They use a new `HashMap` for every apply operation, without any bounds on the size. `lib-bdd-ffi` checks that the cumulated node count of all BDDs belonging to a manager does not exceed some maximum value. This check happens after each apply operation only, i.e., the library might allocate too much memory in between.
- I was a bit unsure whether to use `lib_bdd`, `libbdd`, or `lib-bdd` (the latter would only be applicable in executable names). In the end, I chose `lib_bdd` for the C++ interface to `lib-bdd-ffi`, but `libbdd` for all BDD Benchmark related things (e.g., `libbdd_bdd_adapter`, and executable names).