### PR TITLE
Add More Picotrav Variable Ordering Heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,10 @@ The benchmark can be configured with the following options:
   - `level_df`: Similar to `level` but ties are broken based on the ordering in
     `df` rather than `input`.
 
+  - `fanin`: Similar to `depth-first`, but before recursing, all child nodes are
+    sorted by their depth. Recursive calls are done from the deepest to the most
+    shallow node in order.
+
   - `random`: A randomized ordering of variables.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -540,6 +540,12 @@ The benchmark can be configured with the following options:
   If used twice, the BDDs for both circuits' output gates are constructed and
   checked for logical equality.
 
+- **`-m order|name`** (default: *order*)
+
+  In case two circuits are given as inputs to verify their equivalence, match
+  the inputs and outputs of these circuits by the *order* in which they occur in
+  the input files or by their *names*.
+
 - **`-o <...>`** (default: *input*)
 
   BDD variables represent the value of inputs. Hence, a good variable ordering

--- a/README.md
+++ b/README.md
@@ -554,6 +554,10 @@ The benchmark can be configured with the following options:
 
   - `input`: Use the order in which they are declared in the input *.blif* file.
 
+  - `zip`: Assuming that the input variable order is `a[0]`, `a[1]`, …,
+    `a[n-1]`, `b[0]`, `b[1]`, …, `b[n-1]` in the input *.blif* file, use the
+    order `a[0]`, `b[0]`, `a[1]`, `b[1]`, …, `a[n-1]`, `b[n-1]`.
+
   - `df`/`depth-first`: Variables are ordered based on a depth-first traversal
     where non-input gates are recursed to first; thereby favouring deeper nodes.
 

--- a/src/cnf.cpp
+++ b/src/cnf.cpp
@@ -332,7 +332,7 @@ construct_clauses(Adapter& adapter, const CNF& cnf)
       }
     }
 
-    assert(min_level <= max_var); // holds by the function's precondition
+    assert(min_level <= max_level); // holds by the function's precondition
 
     // ==============================
     // Construct the clause bottom-up

--- a/src/picotrav.cpp
+++ b/src/picotrav.cpp
@@ -32,6 +32,7 @@ enum class variable_order
   DF,
   LEVEL,
   LEVEL_DF,
+  FANIN,
   RANDOM
 };
 
@@ -43,6 +44,7 @@ to_string(const variable_order o)
   case variable_order::DF: return "depth-first";
   case variable_order::LEVEL: return "level";
   case variable_order::LEVEL_DF: return "level-df";
+  case variable_order::FANIN: return "fanin";
   case variable_order::RANDOM: return "random";
   }
   return "?";
@@ -104,6 +106,8 @@ public:
       } else if (lower_arg == "level_depth-first" || lower_arg == "level_df"
                  || lower_arg == "l_df") {
         var_order = variable_order::LEVEL_DF;
+      } else if (lower_arg == "fanin" || lower_arg == "fi") {
+        var_order = variable_order::FANIN;
       } else if (lower_arg == "random" || lower_arg == "r") {
         var_order = variable_order::RANDOM;
       } else {
@@ -483,8 +487,6 @@ construct_net(std::string& filename, net_t& net)
 
 // ========================================================================== //
 // Variable Ordering
-constexpr unsigned UNDEF = std::numeric_limits<unsigned>::max();
-
 void
 dfs_variable_order_rec(const node_id_t id,
                        std::vector<unsigned>& new_ordering,
@@ -595,6 +597,89 @@ level_variable_order(const net_t& net_0, const net_t& net_1)
   return new_ordering;
 }
 
+void
+fanin_variable_order_rec(const node_id_t id,
+                         std::vector<unsigned>& new_ordering,
+                         unsigned& ordered_count,
+                         const net_t& net,
+                         std::vector<bool>& visited)
+{
+  if (ordered_count == net.inputs_w_order.size()) { return; }
+
+  if (visited[id]) { return; }
+  visited[id] = true;
+
+  const node_t& n = net.nodes[id];
+
+  if (n.is_input) {
+    const unsigned old_idx = net.inputs_w_order.at(id);
+    new_ordering[old_idx]  = ordered_count++;
+    return;
+  }
+
+  // Sort dependencies descending by depth
+  std::vector<node_id_t> deps(n.deps);
+  std::sort(deps.begin(), deps.end(), [&net](const node_id_t a, const node_id_t b) {
+    return net.nodes[a].depth > net.nodes[b].depth;
+  });
+
+  for (const node_id_t dep_id : deps) {
+    fanin_variable_order_rec(dep_id, new_ordering, ordered_count, net, visited);
+  }
+}
+
+std::vector<unsigned>
+fanin_variable_order(const net_t& net_0, const net_t& net_1)
+{
+  assert(&net_0.nodes == &net_1.nodes); // pointer equality
+  const std::vector<node_t>& nodes = net_0.nodes;
+
+  std::vector<bool> visited(nodes.size());
+  std::vector<unsigned> new_ordering(net_0.inputs_w_order.size());
+  unsigned ordered_count = 0;
+
+  unsigned output_count = net_0.outputs_in_order.size();
+  if (net_1.outputs_in_order.size() != output_count) { // Only consider `net_0`
+    // Sort dependencies descending by depth
+    std::vector<node_id_t> outputs(net_0.outputs_in_order);
+    std::sort(outputs.begin(), outputs.end(), [&nodes](const node_id_t a, const node_id_t b) {
+      return nodes[a].depth > nodes[b].depth;
+    });
+
+    for (const node_id_t output : outputs) {
+      fanin_variable_order_rec(output, new_ordering, ordered_count, net_0, visited);
+    }
+  } else {
+    // Consider both `net_0` and `net_1`. First, group the output pairs together
+    std::vector<std::pair<node_id_t, node_id_t>> outputs;
+    outputs.reserve(output_count);
+    for (unsigned i = 0; i < output_count; ++i) {
+      outputs.emplace_back(net_0.outputs_in_order[i], net_1.outputs_in_order[i]);
+    }
+    // Sort these pairs descending by their depth (lexicographically maximum, then minimum)
+    std::sort(outputs.begin(), outputs.end(), [&nodes](const auto a, const auto b) {
+      const unsigned a_max = std::max(nodes[a.first].depth, nodes[a.second].depth);
+      const unsigned a_min = std::min(nodes[a.first].depth, nodes[a.second].depth);
+      const unsigned b_max = std::max(nodes[b.first].depth, nodes[b.second].depth);
+      const unsigned b_min = std::min(nodes[b.first].depth, nodes[b.second].depth);
+      return std::tie(a_max, a_min) > std::tie(b_max, b_min);
+    });
+
+    // Recursively visit the children, starting with the deeper node of the pair
+    for (const auto [output_0, output_1] : outputs) {
+      if (nodes[output_0].depth >= nodes[output_1].depth) {
+        fanin_variable_order_rec(output_0, new_ordering, ordered_count, net_0, visited);
+        fanin_variable_order_rec(output_1, new_ordering, ordered_count, net_1, visited);
+      } else {
+        fanin_variable_order_rec(output_1, new_ordering, ordered_count, net_1, visited);
+        fanin_variable_order_rec(output_0, new_ordering, ordered_count, net_0, visited);
+      }
+    }
+  }
+
+  return new_ordering;
+}
+
 std::vector<unsigned>
 random_variable_order(const net_t& net)
 {
@@ -642,6 +727,11 @@ apply_variable_order(const variable_order vo, net_t& net_0, net_t& net_1)
   case variable_order::LEVEL_DF: {
     apply_variable_order(variable_order::DF, net_0, net_1);
     new_ordering = level_variable_order(net_0, net_1);
+    break;
+  }
+
+  case variable_order::FANIN: {
+    new_ordering = fanin_variable_order(net_0, net_1);
     break;
   }
 


### PR DESCRIPTION
This adds the fanin variable ordering heuristic as well as the ZIP heuristic (#21). To respect both circuits in the variable ordering, I had to do a major refactoring. Both nets now contain a mapping from node names (strings) to IDs (integers), which are just indices into a shared node store (a `std::vector`). Also, we match the inputs and outputs if two circuits are given based on their names. I’m not sure, but I think we previously relied on the order in which the inputs/outputs are given. I suppose name-based matching is more desired in cases where it matters. But I could also introduce a command line option, if you want.

In my tests, the ZIP heuristic worked well for, e.g., the adder benchmark, but does not work very well in general. I’ve seen cases where the fanin heuristic significantly outperforms the level DFS heuristic. For instance, verifying that `mem_ctrl_depth_2023` and `mem_ctrl` of the EPFL benchmark suite agree takes only 13 seconds on my laptop (using CUDD and the fanin heuristic).

There are some minor fixes and additions to the CNF benchmark included in this pull request. Is this fine by you or should I split this into two pull requests?

Closes #21