### PR TITLE
Lib bdd/apply relprod

### DIFF
--- a/grendel/grendel_gen.py
+++ b/grendel/grendel_gen.py
@@ -1380,7 +1380,7 @@ def output_path(package, benchmark, dd, args):
 # Script Strings
 # =========================================================================== #
 
-MODULE_LOAD = '''module load gcc/10.1.0
+MODULE_LOAD = '''module load gcc/10.1.0 rust/1.77.1
 module load cmake/3.23.5 autoconf/2.71 automake/1.16.1
 module load boost/1.68.0 gmp/6.2.1'''
 

--- a/grendel/grendel_gen.py
+++ b/grendel/grendel_gen.py
@@ -1383,8 +1383,7 @@ def output_path(package, benchmark, dd, args):
 MODULE_LOAD = '''module load gcc/10.1.0
 module load rust/1.77.1
 module load cmake/3.23.5 autoconf/2.71 automake/1.16.1
-module load boost/1.68.0
-module load gmp/6.2.1'''
+module load boost/1.68.0'''
 
 ENV_SETUP = '''export CC=/comm/swstack/core/gcc/10.1.0/bin/gcc
 export CXX=/comm/swstack/core/gcc/10.1.0/bin/c++

--- a/grendel/grendel_gen.py
+++ b/grendel/grendel_gen.py
@@ -1380,7 +1380,7 @@ def output_path(package, benchmark, dd, args):
 # Script Strings
 # =========================================================================== #
 
-MODULE_LOAD = '''module load gcc/10.1.0
+MODULE_LOAD = '''module load gcc/13.2.0
 module load rust/1.77.1
 module load cmake/3.23.5 autoconf/2.71 automake/1.16.1
 module load boost/1.68.0'''

--- a/grendel/grendel_gen.py
+++ b/grendel/grendel_gen.py
@@ -1380,9 +1380,11 @@ def output_path(package, benchmark, dd, args):
 # Script Strings
 # =========================================================================== #
 
-MODULE_LOAD = '''module load gcc/10.1.0 rust/1.77.1
+MODULE_LOAD = '''module load gcc/10.1.0
+module load rust/1.77.1
 module load cmake/3.23.5 autoconf/2.71 automake/1.16.1
-module load boost/1.68.0 gmp/6.2.1'''
+module load boost/1.68.0
+module load gmp/6.2.1'''
 
 ENV_SETUP = '''export CC=/comm/swstack/core/gcc/10.1.0/bin/gcc
 export CXX=/comm/swstack/core/gcc/10.1.0/bin/c++

--- a/src/apply.cpp
+++ b/src/apply.cpp
@@ -86,7 +86,7 @@ template <typename Adapter>
 int
 run_apply(int argc, char** argv)
 {
-  bool should_exit = parse_input<parsing_policy>(argc, argv);
+  const bool should_exit = parse_input<parsing_policy>(argc, argv);
   if (should_exit) { return -1; }
 
   if (inputs_path.size() < 2) {

--- a/src/libbdd/adapter.h
+++ b/src/libbdd/adapter.h
@@ -147,6 +147,8 @@ namespace lib_bdd
     top() const noexcept;
     bdd_function
     bot() const noexcept;
+    bdd_function
+    load(const std::string &path) const noexcept;
   };
 
   class bdd_function
@@ -399,7 +401,7 @@ namespace lib_bdd
     save(const std::string &path) const noexcept
     {
       assert(_func._p);
-      capi::bdd_writebytes(_func, path.data());
+      capi::bdd_save(_func, path.data());
     }
   };
 
@@ -429,6 +431,13 @@ namespace lib_bdd
   {
     assert(_manager._p);
     return capi::manager_false(_manager);
+  }
+
+  inline bdd_function
+  manager::load(const std::string &path) const noexcept
+  {
+    assert(_manager._p);
+    return capi::bdd_load(_manager, path.data());
   }
 } // namespace lib_bdd
 
@@ -742,6 +751,12 @@ public:
   save(const lib_bdd::bdd_function& f, const std::string& path)
   {
     f.save(path);
+  }
+
+  lib_bdd::bdd_function
+  load(const std::string& path)
+  {
+    return _manager.load(path);
   }
 
   // BDD Build Operations

--- a/src/libbdd/apply_bdd.cpp
+++ b/src/libbdd/apply_bdd.cpp
@@ -2,6 +2,103 @@
 
 #include "adapter.h"
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//                         Benchmark as per Pastva and Henzinger (2023)                           //
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <>
+int
+run_apply<libbdd_bdd_adapter>(int argc, char** argv)
+{
+  const bool should_exit = parse_input<parsing_policy>(argc, argv);
+  if (should_exit) { return -1; }
+
+  if (inputs_path.size() < 2) {
+    std::cerr << "Not enough files provided for binary operation (2+ required)\n";
+    return -1;
+  }
+
+  // =============================================================================================
+  // Initialize BDD package
+  return run<libbdd_bdd_adapter>("apply", 0, [&](libbdd_bdd_adapter& adapter) {
+    std::cout << json::field("inputs") << json::array_open << json::endl;
+
+    // =============================================================================================
+    // Load DDs
+    std::vector<libbdd_bdd_adapter::dd_t> inputs_dd;
+    inputs_dd.reserve(inputs_path.size());
+
+    size_t total_time = 0;
+
+    std::cout << json::field("load") << json::array_open << json::endl << json::flush;
+
+    for (size_t i = 0; i < inputs_path.size(); ++i) {
+      assert(inputs_dd.size() == i);
+
+      const time_point t_rebuild_before = now();
+      inputs_dd.push_back(adapter.load(inputs_path.at(i)));
+      const time_point t_rebuild_after = now();
+
+      const size_t load_time = duration_ms(t_rebuild_before, t_rebuild_after);
+      total_time += load_time;
+
+      std::cout << json::indent << json::brace_open << json::endl;
+      std::cout << json::field("path") << json::value(inputs_path.at(i)) << json::comma
+                << json::endl;
+      std::cout << json::field("size (nodes)") << json::value(adapter.nodecount(inputs_dd.at(i)))
+                << json::comma << json::endl;
+      std::cout << json::field("satcount") << json::value(adapter.satcount(inputs_dd.at(i)))
+                << json::comma << json::endl;
+      std::cout << json::field("time (ms)")
+                << json::value(duration_ms(t_rebuild_before, t_rebuild_after)) << json::endl;
+
+      std::cout << json::brace_close;
+      if (i < inputs_path.size() - 1) { std::cout << json::comma; }
+      std::cout << json::endl;
+    }
+
+    std::cout << json::array_close << json::comma << json::endl;
+
+    // =============================================================================================
+    // Apply DDs together
+    libbdd_bdd_adapter::dd_t result = inputs_dd.at(0);
+
+    std::cout << json::field("apply") << json::brace_open << json::endl << json::flush;
+
+    const time_point t_apply_before = now();
+    for (size_t i = 0; i < inputs_dd.size(); ++i) {
+      switch (oper) {
+      case operand::AND: result &= inputs_dd.at(i); break;
+      case operand::OR: result |= inputs_dd.at(i); break;
+      }
+    }
+    const time_point t_apply_after = now();
+
+    const size_t apply_time = duration_ms(t_apply_before, t_apply_after);
+    total_time += apply_time;
+
+    std::cout << json::field("operand") << json::value(to_string(oper)) << json::comma
+              << json::endl;
+    std::cout << json::field("operations") << json::value(inputs_dd.size() - 1) << json::comma
+              << json::endl;
+    std::cout << json::field("size (nodes)") << adapter.nodecount(result) << json::comma
+              << json::endl;
+    std::cout << json::field("satcount") << adapter.satcount(result) << json::comma << json::endl;
+    std::cout << json::field("time (ms)") << apply_time << json::endl;
+
+    std::cout << json::brace_close << json::comma << json::endl;
+
+    // =============================================================================================
+
+    std::cout << json::field("total time (ms)") << json::value(init_time + total_time)
+              << json::endl;
+
+    return 0;
+  });
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 int
 main(int argc, char** argv)
 {

--- a/src/libbdd/relprod_bdd.cpp
+++ b/src/libbdd/relprod_bdd.cpp
@@ -2,6 +2,151 @@
 
 #include "adapter.h"
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//                         Benchmark as per Pastva and Henzinger (2023)                           //
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <>
+int
+run_relprod<libbdd_bdd_adapter>(int argc, char** argv)
+{
+  const bool should_exit = parse_input<parsing_policy>(argc, argv);
+  if (should_exit) { return -1; }
+
+  if (relation_path == "") {
+    std::cerr << "Path for relation missing\n";
+    return -1;
+  }
+  if (states_path == "") {
+    std::cerr << "Path for states missing\n";
+    return -1;
+  }
+
+  // =============================================================================================
+  // Load 'lib-bdd' files
+  int varcount = 0;
+  {
+    const lib_bdd::bdd libbdd_relation = lib_bdd::deserialize(relation_path);
+    varcount = lib_bdd::stats(libbdd_relation).levels;
+  }
+
+  // =============================================================================================
+  // Initialize BDD package
+  return run<libbdd_bdd_adapter>("relprod", varcount, [&](libbdd_bdd_adapter& adapter) {
+    size_t total_time = 0;
+
+    // =============================================================================================
+    // Reconstruct DDs
+    libbdd_bdd_adapter::dd_t relation = adapter.bot();
+    {
+      std::cout << json::field("relation") << json::brace_open << json::endl;
+
+      std::cout << json::field("path") << json::value(relation_path) << json::comma
+                << json::endl;
+
+      const time_point t_rebuild_before = now();
+      relation = adapter.load(relation_path);
+      const time_point t_rebuild_after = now();
+
+      const size_t rebuild_time = duration_ms(t_rebuild_before, t_rebuild_after);
+      total_time += rebuild_time;
+
+      std::cout << json::field("size (nodes)") << json::value(adapter.nodecount(relation))
+                << json::comma << json::endl;
+      std::cout << json::field("satcount") << json::value(adapter.satcount(relation))
+                << json::comma << json::endl;
+      std::cout << json::field("time (ms)")
+                << json::value(rebuild_time) << json::endl;
+
+      std::cout << json::brace_close << json::comma << json::endl;
+    }
+
+    libbdd_bdd_adapter::dd_t states = adapter.bot();
+    {
+      std::cout << json::field("states") << json::brace_open << json::endl;
+
+      std::cout << json::field("path") << json::value(states_path) << json::comma
+                << json::endl;
+
+      const time_point t_rebuild_before = now();
+      states = adapter.load(states_path);
+      const time_point t_rebuild_after = now();
+
+      const size_t rebuild_time = duration_ms(t_rebuild_before, t_rebuild_after);
+      total_time += rebuild_time;
+
+      std::cout << json::field("size (nodes)") << json::value(adapter.nodecount(states))
+                << json::comma << json::endl;
+      std::cout << json::field("satcount") << json::value(adapter.satcount(states, varcount / 2))
+                << json::comma << json::endl;
+      std::cout << json::field("time (ms)")
+                << json::value(rebuild_time) << json::endl;
+
+      std::cout << json::brace_close << json::comma << json::endl;
+    }
+
+    // =============================================================================================
+    // Relational Support
+    libbdd_bdd_adapter::dd_t support = adapter.bot();
+    {
+      std::cout << json::field("support") << json::brace_open << json::endl;
+
+      const time_point t_build_before = now();
+      support = build_support(adapter, varcount/2);
+      const time_point t_build_after = now();
+
+      const size_t build_time = duration_ms(t_build_before, t_build_after);
+      total_time += build_time;
+
+      std::cout << json::field("size (nodes)") << json::value(adapter.nodecount(support))
+                << json::comma << json::endl;
+      std::cout << json::field("satcount") << json::value(adapter.satcount(support))
+                << json::comma << json::endl;
+      std::cout << json::field("time (ms)")
+                << json::value(build_time) << json::endl;
+
+      std::cout << json::brace_close << json::comma << json::endl;
+    }
+
+    std::cout << json::endl;
+
+    // =============================================================================================
+    // Relational Product
+    libbdd_bdd_adapter::dd_t result = adapter.bot();
+
+    std::cout << json::field("relprod") << json::brace_open << json::endl << json::flush;
+
+    const time_point t_relprod_before = now();
+    switch (oper) {
+    case operand::NEXT: result = adapter.relnext(states, relation, support); break;
+    case operand::PREV: result = adapter.relprev(states, relation, support); break;
+    }
+    const time_point t_relprod_after = now();
+
+    const size_t relprod_time = duration_ms(t_relprod_before, t_relprod_after);
+    total_time += relprod_time;
+
+    std::cout << json::field("operand") << json::value(to_string(oper)) << json::comma
+              << json::endl;
+    std::cout << json::field("size (nodes)") << adapter.nodecount(result) << json::comma
+              << json::endl;
+    std::cout << json::field("satcount") << adapter.satcount(result, varcount) << json::comma << json::endl;
+    std::cout << json::field("time (ms)") << relprod_time << json::endl;
+
+    std::cout << json::brace_close << json::comma << json::endl;
+
+    // =============================================================================================
+    std::cout << json::endl;
+
+    std::cout << json::field("total time (ms)") << json::value(init_time + total_time)
+              << json::endl;
+
+    return 0;
+  });
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 int
 main(int argc, char** argv)
 {

--- a/src/relprod.cpp
+++ b/src/relprod.cpp
@@ -94,26 +94,17 @@ public:
 
 template <typename Adapter>
 typename Adapter::dd_t
-build_support(Adapter& adapter, const lib_bdd::var_map& vm)
+build_support(Adapter& adapter, const int varcount)
 {
   // TODO: We currently assume the relation includes the frame rule and/or touches all variables.
-  const typename Adapter::build_node_t false_ptr = adapter.build_node(false);
-  const typename Adapter::build_node_t true_ptr  = adapter.build_node(true);
-
-  typename Adapter::build_node_t root_ptr  = true_ptr;
-
-  for (int x = vm.size() - 1; 0 <= x; --x) {
-    root_ptr = adapter.build_node(x, false_ptr, root_ptr);
-  }
-
-  return adapter.build();
+  return adapter.cube([](int) { return true;} );
 }
 
 template <typename Adapter>
 int
 run_relprod(int argc, char** argv)
 {
-  bool should_exit = parse_input<parsing_policy>(argc, argv);
+  const bool should_exit = parse_input<parsing_policy>(argc, argv);
   if (should_exit) { return -1; }
 
   if (relation_path == "") {
@@ -200,7 +191,7 @@ run_relprod(int argc, char** argv)
       std::cout << json::field("support") << json::brace_open << json::endl;
 
       const time_point t_build_before = now();
-      support = build_support(adapter, vm);
+      support = build_support(adapter, vm.size());
       const time_point t_build_after = now();
 
       const size_t build_time = duration_ms(t_build_before, t_build_after);


### PR DESCRIPTION
Changes the LibBDD version of the *Apply* and *RelProd* benchmarks to load the BDD directly from the file (rather than with the custom parser). Doing this allows us to circumvent the fact, that LibBDD does not properly support the `build_node` functions (and instead has an entire sub-BDD for each node in the input).