### PR TITLE
`oxidd_zdd_adapter`: Fix `ithvar`/`nithvar`

### DIFF
--- a/src/cnf.cpp
+++ b/src/cnf.cpp
@@ -415,8 +415,16 @@ conjoin(Adapter& adapter, const IT begin, const IT end)
   auto d = std::distance(begin, end);
   if (d == 1) return *begin;
 
-  const IT mid = begin + d / 2;
-  return conjoin(adapter, begin, mid) & conjoin(adapter, mid, end);
+  const IT mid               = begin + d / 2;
+  typename Adapter::dd_t res = conjoin(adapter, begin, mid) & conjoin(adapter, mid, end);
+
+#ifdef BDD_BENCHMARK_STATS
+  const size_t nodecount = adapter.nodecount(res);
+  largest_bdd            = std::max(largest_bdd, nodecount);
+  total_nodes += nodecount;
+#endif // BDD_BENCHMARK_STATS
+
+  return res;
 }
 
 // ========================================================================== //

--- a/src/cnf.cpp
+++ b/src/cnf.cpp
@@ -458,8 +458,7 @@ run_cnf(int argc, char** argv)
 
     const time_duration clause_cons_time = duration_ms(t1, t2);
     std::cout << json::field("amount") << json::value(clauses.size()) << json::comma << json::endl;
-    std::cout << json::field("time (ms)") << json::value(clause_cons_time) << json::comma
-              << json::endl;
+    std::cout << json::field("time (ms)") << json::value(clause_cons_time) << json::endl;
 
     std::cout << json::brace_close << json::comma << json::endl;
 
@@ -480,8 +479,7 @@ run_cnf(int argc, char** argv)
 #ifdef BDD_BENCHMARK_STATS
     std::cout << json::field("total processed (nodes)") << json::value(total_nodes) << json::comma
               << json::endl;
-    std::cout << json::field("largest size (nodes)") << json::value(largest_bdd) << json::comma
-              << json::endl;
+    std::cout << json::field("largest size (nodes)") << json::value(largest_bdd) << json::endl;
     std::cout << json::brace_close << json::comma << json::endl;
 #endif // BDD_BENCHMARK_STATS
     std::cout << json::field("final size (nodes)") << json::value(adapter.nodecount(res))

--- a/src/oxidd/adapter.h
+++ b/src/oxidd/adapter.h
@@ -721,6 +721,7 @@ public:
 
 private:
   oxidd::zbdd_manager _manager;
+  std::vector<oxidd::zbdd_function> _singletons;
   std::vector<oxidd::zbdd_function> _vars;
   oxidd::zbdd_function _latest_build;
 
@@ -729,8 +730,12 @@ public:
   oxidd_zdd_adapter(uint32_t varcount)
     : _manager(compute_init_size(3).first, compute_init_size(3).second, threads)
   {
+    _singletons.reserve(varcount);
+    for (uint32_t i = 0; i < varcount; i++) { _singletons.emplace_back(_manager.new_singleton()); }
     _vars.reserve(varcount);
-    for (uint32_t i = 0; i < varcount; i++) { _vars.emplace_back(_manager.new_singleton()); }
+    for (uint32_t i = 0; i < varcount; i++) {
+      _vars.emplace_back(_singletons[i].var_boolean_function());
+    }
   }
 
   template <typename F>
@@ -924,7 +929,7 @@ public:
   build_node(const int label, const oxidd::zbdd_function& low, const oxidd::zbdd_function& high)
   {
     return _latest_build =
-             _vars[label].make_node(oxidd::zbdd_function(high), oxidd::zbdd_function(low));
+             _singletons[label].make_node(oxidd::zbdd_function(high), oxidd::zbdd_function(low));
   }
 
   inline oxidd::zbdd_function


### PR DESCRIPTION
I just noticed that I probably have implemented these methods wrongly. They should return the Boolean function `x_i`, not the singleton set `{x_i}`, right? (So far I could not find any benchmark/input combination where the change would make a difference, most benchmarks do not seem to use these methods anyway …)

This PR also includes two minor improvements/fixes to the CNF benchmark.