### PR TITLE
Picotrav: Fix Constants

### DIFF
--- a/benchmarks/picotrav/false_a.blif
+++ b/benchmarks/picotrav/false_a.blif
@@ -1,0 +1,5 @@
+.model false_a
+.inputs a
+.outputs b
+.names b
+.end

--- a/benchmarks/picotrav/false_b.blif
+++ b/benchmarks/picotrav/false_b.blif
@@ -1,0 +1,6 @@
+.model false_b
+.inputs a
+.outputs b
+.names b
+ 0
+.end

--- a/src/picotrav.cpp
+++ b/src/picotrav.cpp
@@ -391,7 +391,8 @@ public:
         }
 
         std::vector<logic_value> new_row;
-        bool row_is_onset = false;
+        new_row.reserve(row.size() - 1);
+        bool row_is_onset = true;
 
         auto it = row.begin();
         do {
@@ -402,17 +403,17 @@ public:
           switch (v) {
           case blifparse::LogicValue::FALSE:
             if (is_out_plane) {
-              row_is_onset = true;
+              row_is_onset = false;
             } else {
-              new_row.push_back(logic_value::TRUE);
+              new_row.push_back(logic_value::FALSE);
             }
             break;
 
           case blifparse::LogicValue::TRUE:
             if (is_out_plane) {
-              row_is_onset = false;
+              row_is_onset = true;
             } else {
-              new_row.push_back(logic_value::FALSE);
+              new_row.push_back(logic_value::TRUE);
             }
             break;
 


### PR DESCRIPTION
I noticed that Picotrav claims some outputs of the EPFL benchmark item `router` to differ compared to the optimized (size/depth) variants. All of these output gates are always false, e.g.:

    .names outport[3]
     0

In the optimized versions, here `router_depth_2022.blif`, we have:

    .names $false
    .names $false outport[3]
    1 1

I didn’t really get why the benchmark negates all the values it reads, so I flipped the values back and it works as expected. I added a simple test to the benchmarks folder and also tested this on the `router` and `adder` items of the EPFL suite.