### PR TITLE
Sylvan/libbdd parser crash

### DIFF
--- a/src/common/libbdd_parser.h
+++ b/src/common/libbdd_parser.h
@@ -430,6 +430,13 @@ namespace lib_bdd
       return adapter.build();
     }
 
+    // Reference count
+    std::vector<int> ref_count(in.size(), 0);
+    for (const auto& n : in) {
+      ref_count[n.low()]  += 1;
+      ref_count[n.high()] += 1;
+    }
+
     // Vector of converted DD nodes
     std::unordered_map<int, typename Adapter::build_node_t> out;
 
@@ -457,9 +464,11 @@ namespace lib_bdd
 
       assert(out.find(n.low()) != out.end());
       const auto low  = out[n.low()];
+      if (--ref_count[n.low()] == 0) { out.erase(n.low()); }
 
       assert(out.find(n.high()) != out.end());
       const auto high = out[n.high()];
+      if (--ref_count[n.high()] == 0) { out.erase(n.high()); }
 
       out[*iter] = adapter.build_node(var->second, low, high);
     }

--- a/src/common/libbdd_parser.h
+++ b/src/common/libbdd_parser.h
@@ -431,11 +431,11 @@ namespace lib_bdd
     }
 
     // Vector of converted DD nodes
-    std::vector<typename Adapter::build_node_t> out(in.size(), adapter.build_node(false));
+    std::unordered_map<int, typename Adapter::build_node_t> out;
 
     // Terminal Nodes
-    out.at(0) = adapter.build_node(false);
-    out.at(1) = adapter.build_node(true);
+    out[0] = adapter.build_node(false);
+    out[1] = adapter.build_node(true);
 
     // Internal Nodes
     std::vector<int> work_order;
@@ -455,10 +455,13 @@ namespace lib_bdd
         throw std::out_of_range(ss.str());
       }
 
-      const auto low  = out.at(n.low());
-      const auto high = out.at(n.high());
+      assert(out.find(n.low()) != out.end());
+      const auto low  = out[n.low()];
 
-      out.at(*iter) = adapter.build_node(var->second, low, high);
+      assert(out.find(n.high()) != out.end());
+      const auto high = out[n.high()];
+
+      out[*iter] = adapter.build_node(var->second, low, high);
     }
 
     return adapter.build();


### PR DESCRIPTION
Partially resolves https://github.com/SSoelvsten/bdd-benchmark/issues/138 by decreasing the number of concurrent BDD roots. Yet, this does not as such solve the problem but only push it to further. Sylvan will still crash, if a single level is wider than the Lace stack (or prior, if BDD nodes from multiple levels are still alive).