### PR TITLE
Feature: Print Resource Usage

### DIFF
--- a/src/common/adapter.h
+++ b/src/common/adapter.h
@@ -1,9 +1,11 @@
 #ifndef BDD_BENCHMARK_COMMON_ADAPTER_H
 #define BDD_BENCHMARK_COMMON_ADAPTER_H
 
+#include <cstdint>
 #include <iostream>
 #include <cassert>
 #include <string>
+#include <sys/resource.h>
 
 #include "./chrono.h"
 #include "./input.h"
@@ -36,6 +38,51 @@ ilog2(unsigned long long n)
   return exp;
 #endif
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Print resource usage as JSON object
+////////////////////////////////////////////////////////////////////////////////
+struct resource_usage
+{
+  const rusage& before;
+  const rusage& after;
+  const uint64_t elapsed_ms;
+
+  template <class Elem, class Traits>
+  friend std::basic_ostream<Elem, Traits>&
+  operator<<(std::basic_ostream<Elem, Traits>& os, const resource_usage& self)
+  {
+    const rusage &b = self.before, &a = self.after;
+
+    const uint64_t stime = (a.ru_stime.tv_sec - b.ru_stime.tv_sec) * 1000LL
+      + (a.ru_stime.tv_usec - b.ru_stime.tv_usec) / 1000;
+    const uint64_t utime = (a.ru_utime.tv_sec - b.ru_utime.tv_sec) * 1000LL
+      + (a.ru_utime.tv_usec - b.ru_utime.tv_usec) / 1000;
+
+    os << json::brace_open << json::endl
+       << json::field("stime (ms)") << json::value(stime) << json::comma << json::endl
+       << json::field("utime (ms)") << json::value(utime) << json::comma << json::endl
+       << json::field("CPU (%)")
+       << json::value(self.elapsed_ms > 0 ? (stime + utime) * 100 / self.elapsed_ms : -1)
+       << json::comma << json::endl
+       << json::field("maximum resident set size (MiB)") << json::value(a.ru_maxrss / 1024)
+       << json::comma << json::endl
+       << json::field("minor page faults") << json::value(a.ru_minflt - b.ru_minflt) << json::comma
+       << json::endl
+       << json::field("major page faults") << json::value(a.ru_majflt - b.ru_majflt) << json::comma
+       << json::endl
+       << json::field("block input operations") << json::value(a.ru_inblock - b.ru_inblock)
+       << json::comma << json::endl
+       << json::field("block output operations") << json::value(a.ru_oublock - b.ru_oublock)
+       << json::comma << json::endl
+       << json::field("voluntary context switches") << json::value(a.ru_nvcsw - b.ru_nvcsw)
+       << json::comma << json::endl
+       << json::field("involuntary context switches") << json::value(a.ru_nivcsw - b.ru_nivcsw)
+       << json::endl
+       << json::brace_close;
+    return os;
+  }
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \brief Initializes the BDD package and runs the given benchmark
@@ -101,9 +148,22 @@ run(const std::string& benchmark_name, const int varcount, const F& f)
   std::cout << json::field("name") << json::value(benchmark_name) << json::comma << json::endl
             << json::flush;
 
+  rusage rusage_before;
+  getrusage(RUSAGE_SELF, &rusage_before);
+  time_point start = now();
+
   const int exit_code = adapter.run([&]() { return f(adapter); });
 
-  std::cout << json::brace_close << json::endl << json::brace_close << json::endl << json::flush;
+  rusage rusage_after;
+  getrusage(RUSAGE_SELF, &rusage_after);
+  uint64_t elapsed_ms = duration_ms(start, now());
+
+  std::cout << json::brace_close << json::comma << json::endl
+            << json::endl
+            << json::field("resource usage")
+            << resource_usage{ rusage_before, rusage_after, elapsed_ms } << json::endl
+            << json::brace_close << json::endl
+            << json::flush;
 
 #ifdef BDD_BENCHMARK_STATS
   if (!exit_code) { adapter.print_stats(); }


### PR DESCRIPTION
Uses `getrusage(2)` to generate statistics like these, specifically for the actual benchmark execution (i.e., excluding initialization):

```json
  "resource usage": {
    "stime (ms)": 1,
    "utime (ms)": 84,
    "CPU (%)": 98,
    "maximum resident set size (MiB)": 12,
    "minor page faults": 647,
    "major page faults": 0,
    "block input operations": 0,
    "block output operations": 0,
    "voluntary context switches": 2,
    "involuntary context switches": 1
  }
```